### PR TITLE
SmartStore plugin now using require/define ***Not ready to merge / FYI only***

### DIFF
--- a/PhoneGap/local/MockSmartStore.js
+++ b/PhoneGap/local/MockSmartStore.js
@@ -325,7 +325,7 @@ var MockSmartStore = (function(window, $) {
 })(window, jQuery);
 
 var mockStore = new MockSmartStore();
-mockStore.hookToCordova(cordova);
+mockStore.hookToCordova(require("cordova"));
 
 
 

--- a/PhoneGap/test/SFSmartStoreLoadTestSuite.js
+++ b/PhoneGap/test/SFSmartStoreLoadTestSuite.js
@@ -31,6 +31,8 @@
  */
 if (typeof SmartStoreLoadTestSuite === 'undefined') { 
 
+var smartstore = require("salesforce/plugin/smartstore");
+
 /**
  * Constructor for SmartStoreLoadTestSuite
  */
@@ -63,7 +65,7 @@ SmartStoreLoadTestSuite.prototype.registerSoup = function(soupName, soupIndexes,
 	SFHybridApp.logToConsole("In SFSmartStoreLoadTestSuite.registerSoup: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.registerSoup(soupName, soupIndexes, 
+    smartstore.registerSoup(soupName, soupIndexes, 
 		function(soup) { 
 			if (callback !== null) callback(soup);
 		}, 
@@ -80,7 +82,7 @@ SmartStoreLoadTestSuite.prototype.soupExists = function(soupName, callback) {
 	SFHybridApp.logToConsole("In SFSmartStoreLoadTestSuite.soupExists: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.soupExists(soupName,  
+    smartstore.soupExists(soupName,  
 		function(exists) { 
 			if (callback !== null) callback(exists);
 		}, 
@@ -133,7 +135,7 @@ SmartStoreLoadTestSuite.prototype.removeSoup = function(soupName, callback) {
 	SFHybridApp.logToConsole("In SFSmartStoreLoadTestSuite.removeSoup: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.removeSoup(soupName, 
+    smartstore.removeSoup(soupName, 
 		function() { 
 			if (callback !== null) callback();
 		}, 
@@ -166,7 +168,7 @@ SmartStoreLoadTestSuite.prototype.addGeneratedEntriesToSoup = function(soupName,
  */
 SmartStoreLoadTestSuite.prototype.addEntriesToSoup = function(soupName, entries, callback) {
 	var self = this;
-    navigator.smartstore.upsertSoupEntries(soupName, entries, 
+    smartstore.upsertSoupEntries(soupName, entries, 
 		function(upsertedEntries) {
 			callback(upsertedEntries);
 		}, 
@@ -318,7 +320,7 @@ SmartStoreLoadTestSuite.prototype.testAddAndRetrieveManyEntries  = function() {
 						retrieveIds.push(entryId);
 					}
 					
-					navigator.smartstore.retrieveSoupEntries(self.defaultSoupName,
+					smartstore.retrieveSoupEntries(self.defaultSoupName,
 						retrieveIds, 
 						function(retrievedEntries) {
 						    QUnit.equal(retrievedEntries.length, addedEntries.length,"verify retrieved matches added");

--- a/PhoneGap/test/SFSmartStoreTestSuite.js
+++ b/PhoneGap/test/SFSmartStoreTestSuite.js
@@ -31,6 +31,8 @@
  */
 if (typeof SmartStoreTestSuite === 'undefined') { 
 
+var smartstore = require("salesforce/plugin/smartstore");
+
 /**
  * Constructor for SmartStoreTestSuite
  */
@@ -73,7 +75,7 @@ SmartStoreTestSuite.prototype.registerSoup = function(soupName, soupIndexes, cal
 	SFHybridApp.logToConsole("In SFSmartStoreTestSuite.registerSoup: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.registerSoup(soupName, soupIndexes, 
+    smartstore.registerSoup(soupName, soupIndexes, 
 		function(soup) { 
 			SFHybridApp.logToConsole("registerSoup succeeded");
 			if (callback !== null) callback(soup);
@@ -89,7 +91,7 @@ SmartStoreTestSuite.prototype.soupExists = function(soupName, callback) {
 	SFHybridApp.logToConsole("In SFSmartStoreTestSuite.soupExists: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.soupExists(soupName,  
+    smartstore.soupExists(soupName,  
 		function(exists) { 
 			SFHybridApp.logToConsole("soupExists succeeded");
 			if (callback !== null) callback(exists);
@@ -142,7 +144,7 @@ SmartStoreTestSuite.prototype.removeSoup = function(soupName, callback) {
 	SFHybridApp.logToConsole("In SFSmartStoreTestSuite.removeSoup: soupName=" + soupName);
 	
 	var self = this;
-    navigator.smartstore.removeSoup(soupName, 
+    smartstore.removeSoup(soupName, 
 		function() { 
 			SFHybridApp.logToConsole("removeSoup succeeded");
 			if (callback !== null) callback();
@@ -220,7 +222,7 @@ SmartStoreTestSuite.prototype.addEntriesToSoup = function(soupName, entries, cal
 	SFHybridApp.logToConsole("In SFSmartStoreTestSuite.addEntriesToSoup: " + soupName + " entries.length=" + entries.length);
 
 	var self = this;
-    navigator.smartstore.upsertSoupEntries(soupName, entries, 
+    smartstore.upsertSoupEntries(soupName, entries, 
 		function(upsertedEntries) {
 		    SFHybridApp.logToConsole("addEntriesToSoup of " + upsertedEntries.length + " entries succeeded");
 			callback(upsertedEntries);
@@ -236,7 +238,7 @@ SmartStoreTestSuite.prototype.upsertEntriesToSoupWithExternalIdPath = function(s
     SFHybridApp.logToConsole("In SFSmartStoreTestSuite.upsertEntriesToSoupWithExternalIdPath: " + soupName + " entries.length=" + entries.length + " externalIdPath: " + externalIdPath);
         
     var self = this;
-    navigator.smartstore.upsertSoupEntriesWithExternalId(soupName, entries, externalIdPath,
+    smartstore.upsertSoupEntriesWithExternalId(soupName, entries, externalIdPath,
         function(upsertedEntries) {
             SFHybridApp.logToConsole("upsertEntriesToSoupWithExternalIdPath of " + upsertedEntries.length + " entries succeeded");
             callback(upsertedEntries);
@@ -319,7 +321,7 @@ SmartStoreTestSuite.prototype.testRegisterBogusSoup = function()  {
 	var soupName = null;//intentional bogus soupName
 	var self = this;
 
-	navigator.smartstore.registerSoup(soupName, self.defaultSoupIndexes, 
+	smartstore.registerSoup(soupName, self.defaultSoupIndexes, 
 		function(soupName2) {
 			self.setAssertionFailed("registerSoup should fail with bogus soupName " + soupName2);
 		},
@@ -348,7 +350,7 @@ SmartStoreTestSuite.prototype.testRegisterSoupNoIndices = function()  {
 				function(exists) {
 					QUnit.equals(exists, false, "soup should not already exist");
 					// Create soup
-					navigator.smartstore.registerSoup(soupName, [], 
+					smartstore.registerSoup(soupName, [], 
 						function(soupName2) {
 							self.setAssertionFailed("registerSoup should fail with bogus indices " + soupName2);
 						},
@@ -417,8 +419,8 @@ SmartStoreTestSuite.prototype.testUpsertSoupEntriesWithExternalId = function()  
                 QUnit.equal(entries3.length, 16);
                 
                 // Now, query the soup for all entries, and make sure that we have only 16.
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", null, 25);
-                navigator.smartstore.querySoup(self.defaultSoupName, querySpec,
+                var querySpec = smartstore.buildAllQuerySpec("Name", null, 25);
+                smartstore.querySoup(self.defaultSoupName, querySpec,
                     function(cursor) {
                         QUnit.equal(cursor.totalPages, 1, "Are totalPages correct?");
                         var orderedEntries = cursor.currentPageOrderedEntries;
@@ -429,7 +431,7 @@ SmartStoreTestSuite.prototype.testUpsertSoupEntriesWithExternalId = function()  
                         QUnit.equal(orderedEntries[15]._soupEntryId, 16, "Is the last soup entry ID correct?");
                         QUnit.equal(orderedEntries[15].updatedField, "Mister Toast 15", "Is the last updated field correct?");
                                                                                   
-                        navigator.smartstore.closeCursor(cursor,
+                        smartstore.closeCursor(cursor,
                             function(param) { QUnit.ok(true,"closeCursor ok"); self.finalizeTest(); },
                             function(err) { self.setAssertionFailed("closeCursor failed: " + err); }
                         );
@@ -454,7 +456,7 @@ SmartStoreTestSuite.prototype.testUpsertToNonexistentSoup = function()  {
 	var self = this;
 	var entries = [{a:1},{a:2},{a:3}];
 	
-    navigator.smartstore.upsertSoupEntries("nonexistentSoup", entries, 
+    smartstore.upsertSoupEntries("nonexistentSoup", entries, 
 		function(upsertedEntries) {
 			self.setAssertionFailed("upsertSoupEntries should fail with nonexistent soup ");
 		},
@@ -477,7 +479,7 @@ SmartStoreTestSuite.prototype.testRetrieveSoupEntries = function()  {
 		var soupEntry0Id = entries[0]._soupEntryId;
 		var soupEntry2Id = entries[2]._soupEntryId;
 		
-		navigator.smartstore.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id], 
+		smartstore.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id], 
 			function(retrievedEntries) {
 			    QUnit.equal(retrievedEntries.length, 2);
                                                  
@@ -511,12 +513,12 @@ SmartStoreTestSuite.prototype.testRemoveFromSoup = function()  {
 			soupEntryIds.push(entry._soupEntryId);
 		}
 		
-		navigator.smartstore.removeFromSoup(self.defaultSoupName, soupEntryIds, 
+		smartstore.removeFromSoup(self.defaultSoupName, soupEntryIds, 
 			function(status) {
 				QUnit.equal(status, "OK", "removeFromSoup OK");
 				
-				var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
-				navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+				var querySpec = smartstore.buildAllQuerySpec("Name");
+				smartstore.querySoup(self.defaultSoupName, querySpec, 
 					function(cursor) {
 						var nEntries = cursor.currentPageOrderedEntries.length;
 						QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
@@ -540,14 +542,14 @@ SmartStoreTestSuite.prototype.testQuerySoup = function()  {
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3);
 		
-		var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot");
-	    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		var querySpec = smartstore.buildExactQuerySpec("Name","Robot");
+	    smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				QUnit.equal(cursor.totalPages, 1, "totalPages correct");
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
                 
-                navigator.smartstore.closeCursor(cursor,
+                smartstore.closeCursor(cursor,
                     function(param) { QUnit.ok(true,"closeCursor ok"); self.finalizeTest(); },
                     function(param) { self.setAssertionFailed("closeCursor: " + param); }
                     );
@@ -568,15 +570,15 @@ SmartStoreTestSuite.prototype.testQuerySoupDescending = function()  {
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3);
 		
-		var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending");		
-	    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		var querySpec = smartstore.buildAllQuerySpec("Name", "descending");		
+	    smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				QUnit.equal(cursor.totalPages, 1, "totalPages correct");
 				QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check currentPageOrderedEntries");
 				QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
 				QUnit.equal(cursor.currentPageOrderedEntries[2].Name,"Pro Bono Bonobo","verify last entry");
 				
-                navigator.smartstore.closeCursor(cursor,
+                smartstore.closeCursor(cursor,
                     function(param) { QUnit.ok(true,"closeCursor ok"); self.finalizeTest(); },
                     function(param) { self.setAssertionFailed("closeCursor: " + param); }
                     );
@@ -597,9 +599,9 @@ SmartStoreTestSuite.prototype.testQuerySoupBadQuerySpec = function()  {
 		QUnit.equal(entries.length, 3);
 		
 		//query on a nonexistent index
-		var querySpec = navigator.smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");				
+		var querySpec = smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");				
 		
-	    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+	    smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				self.setAssertionFailed("querySoup with bogus querySpec should fail");
 			}, 
@@ -622,9 +624,9 @@ SmartStoreTestSuite.prototype.testQuerySoupEndKeyNoBeginKey = function()  {
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3);
 		//keep in sync with stuffTestSoup
-		var querySpec = navigator.smartstore.buildRangeQuerySpec("Name",null,"Robot");				
+		var querySpec = smartstore.buildRangeQuerySpec("Name",null,"Robot");				
 
-	    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+	    smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 2, "nEntries matches endKey");
@@ -648,9 +650,9 @@ SmartStoreTestSuite.prototype.testQuerySoupBeginKeyNoEndKey = function()  {
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3);
 		//keep in sync with stuffTestSoup
-		var querySpec = navigator.smartstore.buildRangeQuerySpec("Name","Robot",null);				
+		var querySpec = smartstore.buildRangeQuerySpec("Name","Robot",null);				
 
-	    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+	    smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 2, "nEntries matches beginKey");
@@ -675,9 +677,9 @@ SmartStoreTestSuite.prototype.testManipulateCursor = function()  {
 	this.addGeneratedEntriesToTestSoup(self.NUM_CURSOR_MANIPULATION_ENTRIES, 
 		function(entries) {
 			QUnit.equal(entries.length, self.NUM_CURSOR_MANIPULATION_ENTRIES);
-			var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,10);
+			var querySpec = smartstore.buildAllQuerySpec("Name",null,10);
 			
-		    navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		    smartstore.querySoup(self.defaultSoupName, querySpec, 
 				function(cursor) {
 					QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
 					QUnit.equal(cursor.pageSize, 10, "pageSize correct");
@@ -700,7 +702,7 @@ SmartStoreTestSuite.prototype.forwardCursorToEnd = function(cursor) {
 	SFHybridApp.logToConsole("In SFSmartStoreTestSuite.forwardCursorToEnd");	
 	var self = this;
 	
-	navigator.smartstore.moveCursorToNextPage(cursor, 
+	smartstore.moveCursorToNextPage(cursor, 
 		function(nextCursor) {
 			var pageCount = nextCursor.currentPageIndex + 1;
 			var nEntries = nextCursor.currentPageOrderedEntries.length;
@@ -758,13 +760,13 @@ SmartStoreTestSuite.prototype.testQuerySpecFactories = function() {
 	var endKey = "Zzzzbert";
 	var order = "descending";
 	var pageSize = 17;
-	var query =  navigator.smartstore.buildExactQuerySpec(path,beginKey,pageSize);
+	var query =  smartstore.buildExactQuerySpec(path,beginKey,pageSize);
 	QUnit.equal(query.queryType,"exact","check queryType");
 	QUnit.equal(query.indexPath,path,"check indexPath");
 	QUnit.equal(query.matchKey,beginKey,"check matchKey");
 	QUnit.equal(query.pageSize,pageSize,"check pageSize");
 	
-	query =  navigator.smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize);
+	query =  smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize);
 	QUnit.equal(query.queryType,"range","check queryType");
 	QUnit.equal(query.indexPath,path,"check indexPath");
 	QUnit.equal(query.beginKey,beginKey,"check beginKey");
@@ -772,14 +774,14 @@ SmartStoreTestSuite.prototype.testQuerySpecFactories = function() {
 	QUnit.equal(query.order,order,"check order");
 	QUnit.equal(query.pageSize,pageSize,"check pageSize");
 	
-	query =  navigator.smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize);
+	query =  smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize);
 	QUnit.equal(query.queryType,"like","check queryType");
 	QUnit.equal(query.indexPath,path,"check indexPath");
 	QUnit.equal(query.likeKey,beginKey,"check likeKey");
 	QUnit.equal(query.order,order,"check order");
 	QUnit.equal(query.pageSize,pageSize,"check pageSize");
 	
-	var query =  navigator.smartstore.buildAllQuerySpec(path,order,pageSize);
+	var query =  smartstore.buildAllQuerySpec(path,order,pageSize);
 	QUnit.equal(query.queryType,"range","check queryType");
 	QUnit.equal(query.indexPath,path,"check indexPath");
 	QUnit.equal(query.beginKey,null,"check beginKey");
@@ -796,8 +798,8 @@ SmartStoreTestSuite.prototype.testLikeQuerySpecStartsWith  = function() {
 	
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-		var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%");
-		navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		var querySpec = smartstore.buildLikeQuerySpec("Name","Todd%");
+		smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
@@ -814,8 +816,8 @@ SmartStoreTestSuite.prototype.testLikeQuerySpecEndsWith  = function() {
 	
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-		var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%Stellanova");
-		navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		var querySpec = smartstore.buildLikeQuerySpec("Name","%Stellanova");
+		smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
@@ -832,8 +834,8 @@ SmartStoreTestSuite.prototype.testLikeQueryInnerText  = function() {
 	
 	self.stuffTestSoup(function(entries) {
 		QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-		var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%ono%");
-		navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+		var querySpec = smartstore.buildLikeQuerySpec("Name","%ono%");
+		smartstore.querySoup(self.defaultSoupName, querySpec, 
 			function(cursor) {
 				var nEntries = cursor.currentPageOrderedEntries.length;
 				QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
@@ -858,13 +860,13 @@ SmartStoreTestSuite.prototype.testCompoundQueryPath  = function() {
 					//pick out a compound path value and ensure that we can query for the same entry
 					var selectedEntry = entries[1];
 					var selectedUrl = selectedEntry.attributes.url;
-					var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
-					navigator.smartstore.querySoup(soupName, querySpec, 
+					var querySpec = smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
+					smartstore.querySoup(soupName, querySpec, 
 						function(cursor) {
 							QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "currentPageOrderedEntries correct");
 							var foundEntry = cursor.currentPageOrderedEntries[0];
 							QUnit.equal(foundEntry.attributes.url,selectedUrl,"Verify same entry");
-							navigator.smartstore.closeCursor(cursor,
+							smartstore.closeCursor(cursor,
 			                    function(param) { QUnit.ok(true,"closeCursor ok"); self.finalizeTest(); },
 			                    function(param) { self.setAssertionFailed("closeCursor: " + param); }
 			                    );
@@ -882,7 +884,7 @@ SmartStoreTestSuite.prototype.testEmptyQuerySpec  = function() {
 	
 	var querySpec = new SoupQuerySpec(null);
 	querySpec.queryType = null; 
-	navigator.smartstore.querySoup(self.defaultSoupName, querySpec, 
+	smartstore.querySoup(self.defaultSoupName, querySpec, 
 		function(param) { self.setAssertionFailed("querySoup should have failed"); }, 
 		function(param) { self.finalizeTest(); }
 	);
@@ -902,13 +904,13 @@ SmartStoreTestSuite.prototype.testIntegerQuerySpec  = function() {
 		function(soupName) {
 			self.addEntriesToSoup(soupName,rawEntries,
 				function(entries) {
-					var querySpec = navigator.smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
-					navigator.smartstore.querySoup(soupName, querySpec, 
+					var querySpec = smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
+					smartstore.querySoup(soupName, querySpec, 
 						function(cursor) {
 							QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
 							QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
 							QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify last entry");
-							navigator.smartstore.closeCursor(cursor,
+							smartstore.closeCursor(cursor,
 				                function(param) { QUnit.ok(true,"closeCursor ok"); self.finalizeTest(); },
 				                function(param) { self.setAssertionFailed("closeCursor: " + param); }
 				                );


### PR DESCRIPTION
MockCordova using require/define
However smartstore plugin still defining global classes: SoupIndexSpec, SoupQuerySpec, PagedSoupCursor -> we could move them to their own define

Also, are those changes going to be too disruptive for DF?
