### PR TITLE
moveCursorToNextPage and moveCursorToPreviousPage changes

### DIFF
--- a/PhoneGap/plugins/SFSmartStorePlugin.js
+++ b/PhoneGap/plugins/SFSmartStorePlugin.js
@@ -219,17 +219,21 @@ cordova.define("salesforce/plugin/smartstore", function (require, exports, modul
     var moveCursorToNextPage = function (cursor, successCB, errorCB) {
         var newPageIndex = cursor.currentPageIndex + 1;
         if (newPageIndex >= cursor.totalPages) {
-            throw new Error("moveCursorToNextPage called while on last page");
+            errorCB(cursor, new Error("moveCursorToNextPage called while on last page"));
         }
-        moveCursorToPageIndex(cursor, newPageIndex, successCB, errorCB);
+        else {
+            moveCursorToPageIndex(cursor, newPageIndex, successCB, errorCB);
+        }
     };
 
     var moveCursorToPreviousPage = function (cursor, successCB, errorCB) {
         var newPageIndex = cursor.currentPageIndex - 1;
         if (newPageIndex < 0) {
-            throw new Error("moveCursorToPreviousPage called while on first page");
+            errorCB(cursor, new Error("moveCursorToPreviousPage called while on first page"));
         }
-        moveCursorToPageIndex(cursor, newPageIndex, successCB, errorCB);
+        else {
+            moveCursorToPageIndex(cursor, newPageIndex, successCB, errorCB);
+        }
     };
 
     var closeCursor = function (cursor, successCB, errorCB) {

--- a/PhoneGap/test/SFAbstractSmartStoreTestSuite.js
+++ b/PhoneGap/test/SFAbstractSmartStoreTestSuite.js
@@ -74,6 +74,8 @@ AbstractSmartStoreTestSuite.prototype.moveCursorToPreviousPage = promiser(naviga
 AbstractSmartStoreTestSuite.prototype.registerSoupNoAssertion = promiser(navigator.smartstore, "registerSoup", true);
 AbstractSmartStoreTestSuite.prototype.querySoupNoAssertion = promiser(navigator.smartstore, "querySoup", true);
 AbstractSmartStoreTestSuite.prototype.upsertSoupEntriesNoAssertion = promiser(navigator.smartstore, "upsertSoupEntries", true);
+AbstractSmartStoreTestSuite.prototype.moveCursorToNextPageNoAssertion = promiser(navigator.smartstore, "moveCursorToNextPage", true);
+AbstractSmartStoreTestSuite.prototype.moveCursorToPreviousPageNoAssertion = promiser(navigator.smartstore, "moveCursorToPreviousPage", true);
 
 AbstractSmartStoreTestSuite.prototype.registerDefaultSoup = function() {
     return this.registerSoup(this.defaultSoupName, this.defaultSoupIndexes);

--- a/PhoneGap/test/SFSmartStoreTestSuite.js
+++ b/PhoneGap/test/SFSmartStoreTestSuite.js
@@ -391,7 +391,7 @@ SmartStoreTestSuite.prototype.testQuerySoupBadQuerySpec = function()  {
             return self.querySoupNoAssertion(self.defaultSoupName, querySpec);
         })
         .done(function(cursor) {
-                self.setAssertionFailed("querySoup with bogus querySpec should fail");
+            self.setAssertionFailed("querySoup with bogus querySpec should fail");
         })
         .fail(function(param) { 
             QUnit.ok(true,"querySoup with bogus querySpec should fail");
@@ -494,6 +494,14 @@ SmartStoreTestSuite.prototype.testManipulateCursor = function()  {
         })
         .pipe(function(cursor) {
             checkPage(cursor, 2);
+            return self.moveCursorToPreviousPage(cursor);
+        })
+        .pipe(function(cursor) {
+            checkPage(cursor, 1);
+            return self.moveCursorToNextPage(cursor);
+        })
+        .pipe(function(cursor) {
+            checkPage(cursor, 2);
             return self.closeCursor(cursor);
         })
         .done(function(param) { 
@@ -503,10 +511,10 @@ SmartStoreTestSuite.prototype.testManipulateCursor = function()  {
 };
 
 /**
- * TEST testManipulateCursorOutOfBounds
+ * TEST testMoveCursorToPreviousPageFromFirstPage
  */
-SmartStoreTestSuite.prototype.testManipulateCursorOutOfBounds = function()  {
-  console.log("In SFSmartStoreTestSuite.testManipulateCursorOutOfBounds");  
+SmartStoreTestSuite.prototype.testMoveCursorToPreviousPageFromFirstPage = function()  {
+  console.log("In SFSmartStoreTestSuite.testMoveCursorToPreviousPageFromFirstPage");  
   var self = this;
 
   var NUM_ENTRIES = 8;
@@ -521,35 +529,53 @@ SmartStoreTestSuite.prototype.testManipulateCursorOutOfBounds = function()  {
         })
         .pipe(function(cursor) {
             QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-            try {
-                self.moveCursorToPreviousPage(cursor);
-                self.setAssertionFailed("moveCursorToPreviousPage should have thrown an exception");
-            }
-            catch (e) {
-                QUnit.ok(e.message.indexOf("moveCursorToPreviousPage") == 0, "Expected error about moveCursorToPreviousPage");
-                QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex should not have changed");
-            }
+            return self.moveCursorToPreviousPageNoAssertion(cursor);
+        })
+        .fail(function(cursor, error) {
+            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex should not have changed");
+            QUnit.ok(error.message.indexOf("moveCursorToPreviousPage") == 0, "error should be about moveCursorToPreviousPage");
+            self.closeCursor(cursor)
+                .done(function(param) { 
+                    QUnit.ok(true,"closeCursor ok"); 
+                    self.finalizeTest(); 
+                });
+        });
+};
+
+
+/**
+ * TEST testMoveCursorToNextPageFromLastPage
+ */
+SmartStoreTestSuite.prototype.testMoveCursorToNextPageFromLastPage = function()  {
+  console.log("In SFSmartStoreTestSuite.testMoveCursorToNextPageFromLastPage");  
+  var self = this;
+
+  var NUM_ENTRIES = 8;
+  var PAGE_SIZE = 5;
+  var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 2
+  
+  self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
+        .pipe(function(entries) {
+            QUnit.equal(entries.length, NUM_ENTRIES);
+            var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+            return self.querySoup(self.defaultSoupName, querySpec);
+        })
+        .pipe(function(cursor) {
+            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
             return self.moveCursorToNextPage(cursor);
         })
         .pipe(function(cursor) {
             QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex correct");
-            try {
-                self.moveCursorToNextPage(cursor);
-                self.setAssertionFailed("moveCursorToMextPage should have thrown an exception");
-            }
-            catch (e) {
-                QUnit.ok(e.message.indexOf("moveCursorToNextPage") == 0, "Expected error about moveCursorToNextPage");
-                QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex should not have changed");
-            }
-            return self.moveCursorToPreviousPage(cursor);
+            return self.moveCursorToNextPageNoAssertion(cursor);
         })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
+        .fail(function(cursor, error) {
+            QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex should not have changed");
+            QUnit.ok(error.message.indexOf("moveCursorToNextPage") == 0, "error should be about moveCursorToNextPage");
+            self.closeCursor(cursor)
+                .done(function(param) { 
+                    QUnit.ok(true,"closeCursor ok"); 
+                    self.finalizeTest(); 
+                });
         });
 };
 


### PR DESCRIPTION
- Invoke error callback when at the first (for move to previous) or last page (for move to next)
- added a move to previous in existing testManipulateCursor
- added two new tests: testMoveCursorToPreviousPageFromFirstPage and testMoveCursorToNextPageFromLastPage
- TODO: hook up tests to ForcePluginTests
