### PR TITLE
Updating SalesforceOAuthPlugin.authentictate() input argument.

### DIFF
--- a/PhoneGap/plugins/SalesforceOAuthPlugin.js
+++ b/PhoneGap/plugins/SalesforceOAuthPlugin.js
@@ -91,14 +91,7 @@ cordova.define("salesforce/plugin/oauth", function (require, exports, module) {
      *   userAgent
      */
     var authenticate = function (success, fail, oauthProperties) {
-        var oauthPropertiesJson = {
-            "remoteAccessConsumerKey": oauthProperties.remoteAccessConsumerKey,
-            "oauthRedirectURI": oauthProperties.oauthRedirectURI,
-            "oauthScopes": oauthProperties.oauthScopes,
-            "autoRefreshOnForeground": oauthProperties.autoRefreshOnForeground,
-            "autoRefreshPeriodically": oauthProperties.autoRefreshPeriodically
-        };
-        exec(SDK_VERSION, success, fail, SERVICE, "authenticate", [ oauthPropertiesJson ]);
+        exec(SDK_VERSION, success, fail, SERVICE, "authenticate", [ {"oauthProperties": oauthProperties} ]);
     };
 
     /**


### PR DESCRIPTION
Updating the OAuth properties argument to pass in an actual JSON object, as opposed to a string representation of one.  This is closing the loop to conform to the way the rest of our Cordova plugins pass input arguments.
