### PR TITLE
Serialize cursors with mock SmartStore

### DIFF
--- a/PhoneGap/local/MockSmartStore.js
+++ b/PhoneGap/local/MockSmartStore.js
@@ -78,6 +78,7 @@ var MockSmartStore = (function(window) {
             return JSON.stringify({
                 soups: _soups,
                 soupIndexSpecs: _soupIndexSpecs,
+                cursors: _cursors,
                 nextSoupEltId: _nextSoupEltId,
                 nextCursorId: _nextCursorId
             });


### PR DESCRIPTION
Serialize cursors with mock SmartStore so we don't end up with a null
_cursors object when deserializing from sessionStorage.
