### PR TITLE
Make success callback to pgCloseCursor optional in Mock SmartStore

### DIFF
--- a/PhoneGap/local/MockSmartStore.js
+++ b/PhoneGap/local/MockSmartStore.js
@@ -323,7 +323,9 @@ var MockSmartStore = (function(window) {
             cordova.interceptExec(SMARTSTORE_SERVICE, "pgCloseCursor", function (successCB, errorCB, args) {
                 var cursorId = args[0].cursorId;
                 self.closeCursor(cursorId);
-                successCB("OK");
+                if (successCB) {
+                    successCB("OK");
+                }
             });
         }
 


### PR DESCRIPTION
For consistency with the native SmartStore plugin (on iOS), closing a
cursor without passing a success callback shouldn't fail.

I'm not sure if this is the best place to address this.  Perhaps in `SFSmartStorePlugin.js`, empty callbacks should be passed to `cordova.exec` if they are not passed as parameters?

Also, other actions which don't require callbacks should be updated in the same manner.
