### PR TITLE
Make mock cordova.exec async

### DIFF
--- a/PhoneGap/local/MockCordova.js
+++ b/PhoneGap/local/MockCordova.js
@@ -85,7 +85,9 @@
             var req = service + ":" + action;
             for (var key in interceptors) {
                 if (key === req) {
-                    try { interceptors[key](successCB, errorCB, args); } catch (err) { errorCB(err); }
+                    setTimeout(function() {
+                        try { interceptors[key](successCB, errorCB, args); } catch (err) { errorCB(err); }
+                    }, 0);
                     found = true;
                     break;
                 }


### PR DESCRIPTION
For compatibility with native cordova.exec, the mock implementation needs to be async.

Here's an example where the mock smartstore implementation not being async causes a problem:
http://jsfiddle.net/cwarden/kSQgV/
