### PR TITLE
Fixing contact options to adhere to more strict type checking

### DIFF
--- a/PhoneGap/contactexplorer/inline.js
+++ b/PhoneGap/contactexplorer/inline.js
@@ -5,7 +5,8 @@ function regLinkClickHandlers() {
     var logToConsole = cordova.require("salesforce/util/logger").logToConsole;
     $j('#link_fetch_device_contacts').click(function() {
                                            logToConsole("link_fetch_device_contacts clicked");
-                                           var options = cordova.require("cordova/plugin/ContactFindOptions");
+                                           var contactOptionsType = cordova.require("cordova/plugin/ContactFindOptions");
+                                           var options = new contactOptionsType();
                                            options.filter = ""; // empty search string returns all contacts
                                            options.multiple = true;
                                            var fields = ["name"];


### PR DESCRIPTION
Cordova 2.3 introduced some more strict type checking of input objects.  The way we had contact options defined was technically reporting as a Function, rather than an Object.  I updated the sample to properly initialize the contact options.
