### PR TITLE
Use right query param for SOSL

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -346,7 +346,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.search = function(sosl, callback, error) {
-        this.ajax('/' + this.apiVersion + '/search?s=' + escape(sosl)
+        this.ajax('/' + this.apiVersion + '/search?q=' + escape(sosl)
         , callback, error);
     }
 }


### PR DESCRIPTION
This was fixed much later in forcetk, but we didn't benefit from it since we're on an older version of forcetk.
