### PR TITLE
New hybrid test app name for iOS

### DIFF
--- a/PhoneGap/test/SFSDKInfoTestSuite.js
+++ b/PhoneGap/test/SFSDKInfoTestSuite.js
@@ -58,7 +58,7 @@ SDKInfoTestSuite.prototype.testGetInfo = function()  {
     self.getInfo()
         .done(function(sdkInfo) {
         	QUnit.ok(sdkInfo.sdkVersion.indexOf("2.0unstable") == 0, "expected different sdk version");
-            QUnit.ok(sdkInfo.appName == "DebugPlugins" || sdkInfo.appName == "TestPlugins" || sdkInfo.appName == "ForcePluginsTest", "expected different app name");
+            QUnit.ok(sdkInfo.appName == "HybridPluginTestApp" || sdkInfo.appName == "ForcePluginsTest", "expected different app name");
             QUnit.equal(sdkInfo.appVersion, "1.0", "expected different app version");
             QUnit.equal(sdkInfo.forcePluginsAvailable.length, 4, "wrong force plugins");
             sdkInfo.forcePluginsAvailable.sort();


### PR DESCRIPTION
Conflicts:
    PhoneGap/test/SFSDKInfoTestSuite.js

(Much better :) )
