### PR TITLE
Merge 3 minor fixes from forcetk library (in developerforce) to entity framework's forcetk

### DIFF
--- a/libs/forcetk.js
+++ b/libs/forcetk.js
@@ -133,7 +133,7 @@ if (forcetk.Client === undefined) {
     forcetk.Client.prototype.setSessionToken = function(sessionId, apiVersion, instanceUrl) {
         this.sessionId = sessionId;
         this.apiVersion = (typeof apiVersion === 'undefined' || apiVersion === null)
-        ? 'v24.0': apiVersion;
+        ? 'v27.0': apiVersion;
         if (typeof instanceUrl === 'undefined' || instanceUrl == null) {
             // location.hostname can be of the form 'abc.na1.visual.force.com',
             // 'na1.salesforce.com' or 'abc.my.salesforce.com' (custom domains). 
@@ -168,7 +168,7 @@ if (forcetk.Client === undefined) {
             type: method || "GET",
             async: this.asyncAjax,
             url: (this.proxyUrl !== null) ? this.proxyUrl: url,
-            contentType: 'application/json',
+            contentType: method == "DELETE" || method == "GET" ? null : 'application/json',
             cache: false,
             processData: false,
             data: payload,
@@ -389,7 +389,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.retrieve = function(objtype, id, fieldlist, callback, error) {
-        if (!arguments[4]) {
+        if (arguments.length == 4) {
             error = callback;
             callback = fieldlist;
             fieldlist = null;


### PR DESCRIPTION
Merge 3 minor fixes from forcetk library (in developerforce) to entity framework's forcetk.
1. Fix retrieve method's logic
2. Update version to v27.0
3. Dont send contentType as JSON for GET or DELETE http requests as some libraries like in Node.js Express BodyParser middleware break.
