### PR TITLE
escape method has been deprecated and add return

### DIFF
--- a/libs/forcetk.mobilesdk.js
+++ b/libs/forcetk.mobilesdk.js
@@ -539,7 +539,7 @@ if (forcetk.Client === undefined) {
             fieldlist = null;
         }
         var fields = fieldlist ? '?fields=' + fieldlist : '';
-        this.ajax('/' + this.apiVersion + '/sobjects/' + objtype + '/' + id
+        return this.ajax('/' + this.apiVersion + '/sobjects/' + objtype + '/' + id
         + fields, callback, error);
     }
 
@@ -596,7 +596,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.query = function(soql, callback, error) {
-        return this.ajax('/' + this.apiVersion + '/query?q=' + escape(soql)
+        return this.ajax('/' + this.apiVersion + '/query?q=' + encodeURI(soql)
         , callback, error);
     }
     
@@ -630,7 +630,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.search = function(sosl, callback, error) {
-        return this.ajax('/' + this.apiVersion + '/search?q=' + escape(sosl)
+        return this.ajax('/' + this.apiVersion + '/search?q=' + encodeURI(sosl)
         , callback, error);
     }
 }


### PR DESCRIPTION
escape method has been deprecated since ECMAScript v3.
add return to retrieve's ajax.
