### PR TITLE
Add 'pushNotificationClientId' to 'bootconfig.json'

### DIFF
--- a/SampleApps/contactexplorer/bootconfig.json
+++ b/SampleApps/contactexplorer/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": false,
-    "pushNotificationClientId": ""
+    "androidPushNotificationClientId": ""
 }

--- a/SampleApps/fileexplorer/bootconfig.json
+++ b/SampleApps/fileexplorer/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": true,
-    "pushNotificationClientId": ""
+    "androidPushNotificationClientId": ""
 }

--- a/SampleApps/smartstoreexplorer/bootconfig.json
+++ b/SampleApps/smartstoreexplorer/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": false,
-    "pushNotificationClientId": ""
+    "androidPushNotificationClientId": ""
 }

--- a/SampleApps/smartsync/bootconfig.json
+++ b/SampleApps/smartsync/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": true,
-    "pushNotificationClientId": ""
+    "androidPushNotificationClientId": ""
 }

--- a/SampleApps/vfconnector/bootconfig.json
+++ b/SampleApps/vfconnector/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
 	"shouldAuthenticate": true,
 	"attemptOfflineLoad": false,
-	"pushNotificationClientId": ""
+	"androidPushNotificationClientId": ""
 }

--- a/test/forcepluginstest/bootconfig.json
+++ b/test/forcepluginstest/bootconfig.json
@@ -7,5 +7,5 @@
     "errorPage": "error.html",
     "shouldAuthenticate": true,
     "attemptOfflineLoad": false,
-    "pushNotificationClientId": ""
+    "androidPushNotificationClientId": ""
 }


### PR DESCRIPTION
Default value is empty for now, but this will ensure that the right param is available and easy to plug in when a new app is generated from the template app.
