### PR TITLE
fixing the Smartsync SObjectCollection fetch, where records were being added twice

### DIFF
--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -1220,7 +1220,6 @@
                 Force.fetchSObjects(config, cache, cacheForOriginals)
                     .then(function(resp) {
                         that._fetchResponse = resp;
-                        that.set(resp.records);
                         if (config.closeCursorImmediate) that.closeCursor();
 
                         return resp.records;


### PR DESCRIPTION
Wolf, this is the issue that you fixed in unstable already. But can we push this fix to master as it's currently breaking the UI Elements. We don't need to publish a new version of SDK for this though.
