### PR TITLE
moving the innerForcetkClient to avoid confusion of API

### DIFF
--- a/SampleApps/fileexplorer/FileExplorer.html
+++ b/SampleApps/fileexplorer/FileExplorer.html
@@ -106,7 +106,7 @@ app.models.File = Force.RemoteObject.extend({
     // adding computed fields
     toJSON: function() {
         var that = this;
-        return _.extend(Backbone.Model.prototype.toJSON.call(this), {thumbnailUrl: Force.innerForcetkClient.instanceUrl + that.get('renditionUrl')});
+        return _.extend(Backbone.Model.prototype.toJSON.call(this), {thumbnailUrl: Force.forcetkClient.impl.instanceUrl + that.get('renditionUrl')});
     }
 });
 

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -86,6 +86,7 @@
         }
 
         forcetkClient = new Object();
+        forcetkClient.impl = innerForcetkClient;
         forcetkClient.create = promiser(innerForcetkClient, "create", "forcetkClient");
         forcetkClient.retrieve = promiser(innerForcetkClient, "retrieve", "forcetkClient");
         forcetkClient.update = promiser(innerForcetkClient, "update", "forcetkClient");
@@ -104,7 +105,6 @@
 
         // Exposing outside
         Force.forcetkClient = forcetkClient;
-        Force.innerForcetkClient = innerForcetkClient;
 
         if (navigator.smartstore) 
         {


### PR DESCRIPTION
Not a biggie, but just to avoid the confusion of two forcetkClient APIs exposed from same place.
