### PR TITLE
removing the use of /services/proxy

### DIFF
--- a/libs/forcetk.mobilesdk.js
+++ b/libs/forcetk.mobilesdk.js
@@ -79,17 +79,10 @@ if (forcetk.Client === undefined) {
         this.clientId = clientId;
         this.loginUrl = loginUrl || 'https://login.salesforce.com/';
         if (typeof proxyUrl === 'undefined' || proxyUrl === null) {
-            if (location.protocol === 'file:') {
-                // In Cordova
-                this.proxyUrl = null;
-            } else {
-                // In Visualforce
-                this.proxyUrl = location.protocol + "//" + location.hostname
-                    + "/services/proxy";
-            }
+            this.proxyUrl = null;
             this.authzHeader = "Authorization";
         } else {
-            // On a server outside VF
+            // On an external proxy service
             this.proxyUrl = proxyUrl;
             this.authzHeader = "X-Authorization";
         }


### PR DESCRIPTION
Since API requests are now allowed directly from VF pages. Don't need to call the /services/proxy.
