### PR TITLE
fixing getMore callback on soql. using _.union to combine results

### DIFF
--- a/SampleApps/fileexplorer/FileExplorer.html
+++ b/SampleApps/fileexplorer/FileExplorer.html
@@ -83,7 +83,7 @@
 
   <div class="content">
     <div class="content-padded">
-      <img src="<%= thumbnailUrl %>" class="large-img" /> 
+      <img src="<%= thumbnailUrl %>" class="large-img" />
       <div class="details">
         <b><%= title %></b><br/>
         <%= owner.name %><br/>
@@ -127,7 +127,7 @@ app.models.FileCollection = Force.RemoteObjectCollection.extend({
         };
 
         return fetchPromise
-            .then(function(resp) { 
+            .then(function(resp) {
                 var nextPageUrl = resp.nextPageUrl;
                 return {
                     totalSize: resp.files.length,
@@ -138,7 +138,7 @@ app.models.FileCollection = Force.RemoteObjectCollection.extend({
                         if (!nextPageUrl) return null;
                         return forcetkClient.queryMore(nextPageUrl).then(function(resp) {
                             nextPageUrl = resp.nextPageUrl;
-                            that.records.pushObjects(resp.files);
+                            that.records = _.union(that.records, resp.files);
                             return resp.files;
                         });
                     },
@@ -244,7 +244,7 @@ app.Router = Backbone.StackRouter.extend({
         "list": "list",
         "files/:id": "viewFile"
     },
-                                         
+
     initialize: function() {
         Backbone.Router.prototype.initialize.call(this);
 

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -1073,7 +1073,7 @@
                             if (!nextRecordsUrl) return null;
                             return forcetkClient.queryMore(nextRecordsUrl).then(function(resp) {
                                 nextRecordsUrl = resp.nextRecordsUrl;
-                                that.records.pushObjects(resp.records);
+                                that.records = _.union(that.records, resp.records);
                                 return resp.records;
                             });
                         },
@@ -1164,7 +1164,7 @@
                             if (!nextRecordsUrl) return null;
                             return forcetkClient.queryMore(nextRecordsUrl).then(function(resp) {
                                 nextRecordsUrl = resp.nextRecordsUrl;
-                                that.records.pushObjects(resp.records);
+                                that.records = _.union(that.records, resp.records);
                                 return resp.records;
                             });
                         },


### PR DESCRIPTION
Was using a method pushObjects earlier, which doesn't really exist.
