### PR TITLE
Adding shared cordovaHelper.js

### DIFF
--- a/node/cordovaHelper.js
+++ b/node/cordovaHelper.js
@@ -1,0 +1,18 @@
+var shelljs = require('shelljs');
+
+/**
+ * Gets the the version of the currently installed cordova CLI tool.
+ *
+ * @return {String} The version of the cordova CLI tool, or null if the tool is not installed.
+ */
+var getCordovaCliVersion = function() {
+	var cordovaVersionResult = shelljs.exec('cordova -v', { 'silent' : true });
+    if (cordovaVersionResult.code !== 0) {
+        return null;
+    }
+
+    var cordovaCliVersion = cordovaVersionResult.output.replace('\n', '');
+    return cordovaCliVersion;
+};
+
+module.exports.getCordovaCliVersion = getCordovaCliVersion;


### PR DESCRIPTION
Moving the version checker into a shared module as well, as Android will use it too.
