### PR TITLE
Tests to exercise concurrent upserts on the same data from hybrid

### DIFF
--- a/test/SFAbstractSmartStoreTestSuite.js
+++ b/test/SFAbstractSmartStoreTestSuite.js
@@ -181,6 +181,11 @@ AbstractSmartStoreTestSuite.prototype.addEntriesToTestSoup = function(entries) {
     console.log("In addEntriesToTestSoup: entries.length=" + entries.length);
     return this.upsertSoupEntries(this.defaultSoupName,entries);
 };
+    
+AbstractSmartStoreTestSuite.prototype.addEntriesWithExternalIdToTestSoup = function(entries, externalIdPath) {
+    console.log("In addEntriesWithExternalIdToTestSoup: entries.length=" + entries.length);
+    return this.upsertEntriesToSoupWithExternalIdPath(this.defaultSoupName, entries, externalIdPath);
+};
 
 }
 


### PR DESCRIPTION
`testUpsertConcurrentEntries` will fire off a (configurable) 100 "concurrent" SmartStore upsert requests, each with a batch of the same 20 objects by key, with different values.  It will then ensure that the last batch of entries in (as determined by lastModifiedDate of the upsert results) matches the retrieved entries by query.
