### PR TITLE
Fixed a bug: Backbone is not defined.

### DIFF
--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -1557,4 +1557,4 @@
 
     } // if (!_.isUndefined(Backbone)) {
 })
-.call(this, jQuery, _, Backbone, forcetk);
+.call(this, jQuery, _, window.Backbone, forcetk);


### PR DESCRIPTION
When you use `window.Backbone` javascript will use `undefined`.  That way line 1276: `if (!_.isUndefined(Backbone)) {` will work. (https://github.com/forcedotcom/SalesforceMobileSDK-Shared/blob/master/libs/smartsync.js#L1276)

Or should this bug fixed on the _unstable_ branch?
