### PR TITLE
Hybrid changes for sync down without overwrite of dirty records

### DIFF
--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -250,7 +250,7 @@
 
             var that = this;
 
-            if(_.isUndefined(mergeMode)) mergeMode = Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS;
+            if(!mergeMode || mergeMode == null) mergeMode = Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS;
 
             var mergeIfRequested = function() {
                 if (mergeMode == Force.MERGE_MODE_DOWNLOAD.OVERWRITE) {
@@ -259,7 +259,10 @@
                 else if (mergeMode == Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS) {
                     return that.retrieve(record[that.keyField])
                         .then(function(oldRecord) {
-                            return _.extend(oldRecord || {}, record);
+                            if (mergeMode == Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS)
+                                return _.extend(oldRecord || {}, record);
+                            else if (mergeMode == Force.MERGE_MODE_DOWNLOAD.LEAVE_IF_CHANGED)
+                                return (oldRecord && oldRecord.__local__ ? oldRecord : record);
                         });
                 }
             };
@@ -280,7 +283,7 @@
             Force.console.debug("----> In StoreCache:saveAll records.length=" + records.length + " mergeMode:" + mergeMode);
 
 
-            if(_.isUndefined(mergeMode)) mergeMode = Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS;
+            if(!mergeMode || mergeMode == null) mergeMode = Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS;
 
             var that = this;
 
@@ -288,7 +291,7 @@
                 if (mergeMode == Force.MERGE_MODE_DOWNLOAD.OVERWRITE) {
                     return $.when(records);
                 }
-                else if (mergeMode == Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS) {
+                else {
                     if (_.any(records, function(record) { return !_.has(record, that.keyField); })) {
                         throw new Error("Can't merge without " + that.keyField);
                     }
@@ -313,7 +316,11 @@
                         .then(function() {
                             return _.map(records, function(record) {
                                 var oldRecord = oldRecords[record[that.keyField]];
-                                return _.extend(oldRecord || {}, record)
+
+                                if (mergeMode == Force.MERGE_MODE_DOWNLOAD.MERGE_ACCEPT_THEIRS)
+                                    return _.extend(oldRecord || {}, record);
+                                else if (mergeMode == Force.MERGE_MODE_DOWNLOAD.LEAVE_IF_CHANGED)
+                                    return (oldRecord && oldRecord.__local__ ? oldRecord : record);
                             });
                         });
                 }
@@ -1240,8 +1247,8 @@
     //
     // Returns a promise
     //
-    Force.fetchRemoteObjects = function(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals) {
-        Force.console.info("--> In Force.fetchRemoteObjects:cacheMode=" + cacheMode);
+    Force.fetchRemoteObjects = function(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals, mergeMode) {
+        Force.console.info("--> In Force.fetchRemoteObjects:cacheMode=" + cacheMode + ":mergeMode=" + mergeMode);
 
         var promise;
 
@@ -1263,11 +1270,11 @@
                 };
 
                 var cacheSaveAll = function(records) {
-                    return cache.saveAll(records);
+                    return cache.saveAll(records, mergeMode);
                 };
 
                 var cacheForOriginalsSaveAll = function(records) {
-                    return cacheForOriginals != null ? cacheForOriginals.saveAll(records) : records;
+                    return cacheForOriginals != null ? cacheForOriginals.saveAll(records, mergeMode) : records;
                 };
 
                 var setupGetMore = function(records) {
@@ -1298,7 +1305,7 @@
     //
     // Returns a promise
     //
-    Force.fetchSObjects = function(config, cache, cacheForOriginals) {
+    Force.fetchSObjects = function(config, cache, cacheForOriginals, mergeMode) {
         Force.console.info("--> In Force.fetchSObjects:config.type=" + config.type);
 
         var fetchFromServer = function() {
@@ -1311,7 +1318,7 @@
 
         var cacheMode = (config.type == "cache" ? Force.CACHE_MODE.CACHE_ONLY : Force.CACHE_MODE.SERVER_FIRST);
 
-        return Force.fetchRemoteObjects(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals);
+        return Force.fetchRemoteObjects(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals, mergeMode);
     };
 
     if (!_.isUndefined(Backbone)) {
@@ -1440,6 +1447,9 @@
             // Used if none is passed during sync call - can be a cache object or a function returning a cache object
             cacheForOriginals: null,
 
+            // Used if none is passed during sync call - can be Fore.MERGE_MODE_DOWNLOAD or a function returning a cache object
+            mergeMode: null,
+
             // To be defined in concrete subclass
             fetchRemoteObjectFromServer: function(config) {
                 return $.when([]);
@@ -1476,6 +1486,7 @@
             // Extra options (can also be defined as properties of the model object)
             // * config:<see above for details>
             // * cache:<cache object>
+            // * mergeMode:<any Force.MERGE_MODE_DOWNLOAD values>
             sync: function(method, model, options) {
                 Force.console.debug("-> In Force.RemoteObjectCollection:sync method=" + method);
                 var that = this;
@@ -1487,6 +1498,7 @@
                 var config = options.config || _.result(this, "config");
                 var cache = options.cache   || _.result(this, "cache");
                 var cacheForOriginals = options.cacheForOriginals || _.result(this, "cacheForOriginals");
+                var mergeMode = options.mergeMode || _.result(this, "mergeMode");
 
                 if (config == null) {
                     options.success([]);
@@ -1532,7 +1544,7 @@
                 var cacheMode = (config.type == "cache" ? Force.CACHE_MODE.CACHE_ONLY : Force.CACHE_MODE.SERVER_FIRST);
 
                 options.reset = true;
-                Force.fetchRemoteObjects(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals)
+                Force.fetchRemoteObjects(fetchFromServer, fetchFromCache, cacheMode, cache, cacheForOriginals, mergeMode)
                     .then(function(resp) {
                         that._fetchResponse = resp;
                         if (config.closeCursorImmediate) that.closeCursor();

--- a/test/MockSmartSyncPlugin.js
+++ b/test/MockSmartSyncPlugin.js
@@ -95,7 +95,8 @@ var MockSmartSyncPlugin = (function(window) {
                     success: onFetch,
                     error: function() {
                         self.sendUpdate(syncId, "FAILED", 0);
-                    }
+                    },
+                    mergeMode: options.mergeMode
                 });
             });
         },

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -180,7 +180,7 @@ SmartSyncTestSuite.prototype.testStoreCacheSave = function() {
         assertContains(records[0], {Id:"007", Name:"JamesBond", Mission:"TopSecret2", Organization:"MI6"});
 
         console.log("## Saving partial record to cache with noMerge flag");
-        return cache.save({Id:"007", Mission:"TopSecret3"}, true);
+        return cache.save({Id:"007", Mission:"TopSecret3"}, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
     })
     .then(function(record) {
         console.log("## Direct retrieve from underlying cache");
@@ -249,7 +249,7 @@ SmartSyncTestSuite.prototype.testStoreCacheSaveAll = function() {
 
         console.log("## Saving partial records to cache with noMerge flag");
         var partialRecords = [{Id:"007", Mission:"TopSecret"},{Id:"008", Team:"Team"}, {Id:"009", Organization:"Org"}];        
-        return cache.saveAll(partialRecords, true);
+        return cache.saveAll(partialRecords, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
     })
     .then(function(records) {
         console.log("## Direct retrieve from underlying cache");
@@ -2652,7 +2652,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
             _.each(_.keys(idToName), function(id) {
                 updatedRecords.push({Id:id, Name:idToName[id]+"Updated", __locally_updated__:true});
             });
-            return cache.saveAll(updatedRecords, false);
+            return cache.saveAll(updatedRecords);
         })
         .then(function(records) {
             console.log("## Calling sync up");
@@ -2713,7 +2713,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
             _.each(_.keys(idToName), function(id) {
                 deletedRecords.push({Id:id, __locally_deleted__:true});
             });
-            return cache.saveAll(deletedRecords, false);
+            return cache.saveAll(deletedRecords);
         })
         .then(function(records) {
             console.log("## Calling sync up");
@@ -2766,7 +2766,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyCreated = function() {
             for (var i=0; i<3; i++) {
                 createdRecords.push({Id:"local_" + i, Name:"testSyncUpLocallyCreated" + i, __locally_created__:true, attributes:{type:"Account"}});
             }
-            return cache.saveAll(createdRecords, false);
+            return cache.saveAll(createdRecords);
         })
         .then(function(records) {
             console.log("## Calling sync up");

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -2603,7 +2603,7 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
         })
         .then(function() {
             console.log("## Calling sync down");
-            return self.trySyncDown(cache, soupName, idToName);
+            return self.trySyncDown(cache, soupName, idToName, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
         })
         .then(function() {
             return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
@@ -2612,6 +2612,83 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
             self.finalizeTest();
         });
 };
+
+/** 
+ * TEST smartsyncplugin sync down with merge mode leave-if-changed
+ */
+SmartSyncTestSuite.prototype.testSyncDownWithNoOverwrite = function() {
+    console.log("# In SmartSyncTestSuite.testSyncDownWithNoOverwrite");
+    var self = this;
+    var idToName = {};
+    var idToUpdatedName = {};
+    var updatedRecords;
+    var options = {fieldlist: ["Name"]};
+    var soupName = "testSyncDownWithNoOverwrite";
+    var cache;
+
+    Force.smartstoreClient.removeSoup(soupName)
+        .then(function() {
+            console.log("## Initialization of StoreCache's");
+            cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
+            return $.when(cache.init());
+        })
+        .then(function() { 
+            console.log("## Direct creation against server");    
+            return createRecords(idToName, "testFetchSObjects", 3);
+        })
+        .then(function() {
+            console.log("## Calling sync down");
+            return self.trySyncDown(cache, soupName, idToName);
+        })
+        .then(function() {
+            console.log("## Updating local records");
+            updatedRecords = [];
+            _.each(_.keys(idToName), function(id) {
+                idToUpdatedName[id] = idToName[id]+"Updated";
+                updatedRecords.push({Id:id, Name:idToUpdatedName[id], __locally_updated__:true});
+            });
+            return cache.saveAll(updatedRecords);
+        })
+        .then(function() {
+            console.log("## Calling sync down with mergeMode leave-if-changed");
+            return self.trySyncDown(cache, soupName, idToUpdatedName, Force.MERGE_MODE_DOWNLOAD.LEAVE_IF_CHANGED);
+        })
+        .then(function() {
+            console.log("## Checking cache");
+            return cache.find({queryType:"range", indexPath:"Name", order:"ascending", pageSize:3});
+        })
+        .then(function(result) {
+            console.log("## Checking data retured from cache");
+            QUnit.equals(result.records.length, 3, "Expected 3 records");
+            _.each(result.records, function(record) {
+                QUnit.ok(record.__local__, "Record should still be marked as local");
+                QUnit.ok(record.__locally_updated__, "Record should still be marked as updated");
+                QUnit.ok(record.Name.endsWith("Updated"), "Record name should still have update");                
+            });
+
+            console.log("## Calling sync down with mergeMode overwrite");
+            return self.trySyncDown(cache, soupName, idToName, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
+        })
+        .then(function() {
+            console.log("## Checking cache");
+            return cache.find({queryType:"range", indexPath:"Name", order:"ascending", pageSize:3});
+        })
+        .then(function(result) {
+            console.log("## Checking data retured from cache");
+            QUnit.equals(result.records.length, 3, "Expected 3 records");
+            _.each(result.records, function(record) {
+                QUnit.ok(!record.__local__, "Record should no longer be marked as local");
+                QUnit.ok(!record.__locally_updated__, "Record should no longer be marked as updated");
+                QUnit.ok(!record.Name.endsWith("Updated"), "Record name should no longer have update");                
+            });
+
+            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+        })
+        .then(function() {
+            self.finalizeTest();
+        });
+};
+
 
 
 //-------------------------------------------------------------------------------------------------------
@@ -2644,7 +2721,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
         })
         .then(function() {
             console.log("## Calling sync down");
-            return self.trySyncDown(cache, soupName, idToName);
+            return self.trySyncDown(cache, soupName, idToName, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
         })
         .then(function() {
             console.log("## Updating local records");
@@ -2705,7 +2782,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
         })
         .then(function() {
             console.log("## Calling sync down");
-            return self.trySyncDown(cache, soupName, idToName);
+            return self.trySyncDown(cache, soupName, idToName, Force.MERGE_MODE_DOWNLOAD.OVERWRITE);
         })
         .then(function() {
             console.log("## Deleted local records");
@@ -3031,18 +3108,19 @@ var tryConflictDetection = function(message, cache, cacheForOriginals, theirs, y
 /**
  Helper function to run sync down and consume all status updates until done
  */
-SmartSyncTestSuite.prototype.trySyncDown = function(cache, soupName, idToName) {
+SmartSyncTestSuite.prototype.trySyncDown = function(cache, soupName, idToName, mergeMode) {
+    var options = {mergeMode: mergeMode};
     var target = {type:"soql", query:"SELECT Id, Name FROM Account WHERE Id IN ('" +  _.keys(idToName).join("','") + "') ORDER BY Name"};
     var numberRecords = _.keys(idToName).length;
-    return this.syncDown(target, soupName, {})
+    return this.syncDown(target, soupName, options)
         .then(function(sync) {
             console.log("## Checking sync");
-            assertContains(sync, {type:"syncDown", target: target, status:"RUNNING", progress:0, soupName: soupName});
+            assertContains(sync, {type:"syncDown", target: target, status:"RUNNING", progress:0, soupName: soupName, options:options});
             return eventPromiser(document, "sync", function(event) { return event.detail.status == "DONE";});
         })
         .then(function(event) {
             console.log("## Checking event");
-            assertContains(event.detail, {type:"syncDown", target: target, status:"DONE", progress:100, soupName: soupName});
+            assertContains(event.detail, {type:"syncDown", target: target, status:"DONE", progress:100, soupName: soupName, options:options});
 
             console.log("## Checking cache");
             return cache.find({queryType:"range", indexPath:"Name", order:"ascending", pageSize:numberRecords});


### PR DESCRIPTION
The mock smartsync plugin uses a smartsync.js SObjectCollection to do a sync down.
So I enhanced SObjectCollection to support a new option: merge mode (from the "enum" Force.MERGE_MODE_DOWNLOAD.
I also added a new test that does a sync down with merge mode leave-if-changed.