### PR TITLE
Fix to prevent a crash when a lookup field is null

### DIFF
--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -218,7 +218,7 @@
                 var o = soupElt;
                 for (var i = 0; i<pathElements.length; i++) {
                     var pathElement = pathElements[i];
-                    if (!_.has(o, pathElement)) {
+					if (!o || !_.has(o, pathElement)) {
                         return false;
                     }
                     o = o[pathElement];


### PR DESCRIPTION
When a lookup field is null and a field on the object was being queried for, there was a crash happening. Added check to make sure the lookup field is not null before querying for the related field