### PR TITLE
Refresh token fails when network changes

### DIFF
--- a/libs/forcetk.mobilesdk.js
+++ b/libs/forcetk.mobilesdk.js
@@ -224,7 +224,12 @@ if (forcetk.Client === undefined) {
         var that = this;
         if (typeof this.authCallback === 'undefined' || this.authCallback === null) {
             if (this.refreshToken) {
-                var url = this.loginUrl + '/services/oauth2/token';
+                //Login URL is used to refresh the token which fails. Instance url works and should be used to refresh the token.
+                var url = this.loginUrl;
+                if(this.instanceUrl != null && this.instanceUrl != '') {
+                  url=this.instanceUrl;
+                }
+                url += '/services/oauth2/token';
                 return $j.ajax({
                     type: 'POST',
                     url: (this.proxyUrl !== null) ? this.proxyUrl: url,


### PR DESCRIPTION
When app goes offline or changes the network, token expires and it tries to refresh the token. This refresh token uses login url and fails to refresh. This fix uses the instance url to refresh the token which makes it successful.