### PR TITLE
Changing test script to build iOS app scheme

### DIFF
--- a/node/test_force.js
+++ b/node/test_force.js
@@ -246,7 +246,7 @@ function createCompileApp(tmpDir, appType, os) {
             var workspacePath = path.join(appDir, appName + '.xcworkspace');
             runProcessThrowError('pod update', appDir);    
             runProcessCatchError('xcodebuild -workspace ' + workspacePath 
-                                 + ' -scheme Pods-' + appName // XXX building Pods-<appName> scheme because <appName> scheme only appears after project is opened in XCode !!
+                                 + ' -scheme ' + appName
                                  + ' clean build', 
                                  'COMPILING ' + target); 
         }


### PR DESCRIPTION
Switching to building the app scheme directly, after the updates to support shared schemes for the iOS template apps.