### PR TITLE
Use stdout instead of output

### DIFF
--- a/node/cordovaHelper.js
+++ b/node/cordovaHelper.js
@@ -11,7 +11,7 @@ var getCordovaCliVersion = function() {
         return null;
     }
 
-    var cordovaCliVersion = cordovaVersionResult.output.replace('\n', '');
+    var cordovaCliVersion = cordovaVersionResult.stdout.replace('\n', '');
     return cordovaCliVersion;
 };
 


### PR DESCRIPTION
The latest version of shelljs does not use the output(deprecated in 0.6 and removed in 0.7) property of exec any more. It has been replaced by stdout.

https://github.com/shelljs/shelljs/wiki/Migrating-from-v0.6-to-v0.7
https://github.com/shelljs/shelljs/wiki/Migrating-from-v0.5.3-to-v0.6 