### PR TITLE
Adding React support for external soup storage

### DIFF
--- a/libs/react.force.smartstore.js
+++ b/libs/react.force.smartstore.js
@@ -34,6 +34,14 @@ var exec = function(successCB, errorCB, methodName, args) {
 };
 
 /**
+ * SoupSpec consturctor
+ */
+var SoupSpec = function (soupName, features) {
+    this.soupName = soupName;
+    this.features = features;
+};
+
+/**
  * SoupIndexSpec consturctor
  */
 var SoupIndexSpec = function (path, type) {
@@ -179,12 +187,20 @@ var registerSoup = function (isGlobalStore, soupName, indexSpecs, successCB, err
     exec(successCB, errorCB, "registerSoup", {"soupName": soupName, "indexes": indexSpecs, "isGlobalStore": isGlobalStore});
 };
 
+var registerSoupWithSpec = function (isGlobalStore, soupSpec, indexSpecs, successCB, errorCB) {
+    exec(successCB, errorCB, "registerSoup", {"soupSpec": soupSpec, "indexes": indexSpecs, "isGlobalStore": isGlobalStore});
+};
+
 var removeSoup = function (isGlobalStore, soupName, successCB, errorCB) {
     exec(successCB, errorCB, "removeSoup", {"soupName": soupName, "isGlobalStore": isGlobalStore});
 };
 
 var getSoupIndexSpecs = function(isGlobalStore, soupName, successCB, errorCB) {
     exec(successCB, errorCB, "getSoupIndexSpecs", {"soupName": soupName, "isGlobalStore": isGlobalStore});
+};
+
+var getSoupSpec = function(isGlobalStore, soupName, successCB, errorCB) {
+    exec(successCB, errorCB, "getSoupSpec", {"soupName": soupName, "isGlobalStore": isGlobalStore});
 };
 
 var alterSoup = function (isGlobalStore, soupName, indexSpecs, reIndexData, successCB, errorCB) {
@@ -280,12 +296,14 @@ module.exports = {
     closeCursor: closeCursor,
     getDatabaseSize: getDatabaseSize,
     getSoupIndexSpecs: getSoupIndexSpecs,
+    getSoupSpec: getSoupSpec,
     moveCursorToNextPage: moveCursorToNextPage,
     moveCursorToPageIndex: moveCursorToPageIndex,
     moveCursorToPreviousPage: moveCursorToPreviousPage,
     querySoup: querySoup,
     reIndexSoup: reIndexSoup,
     registerSoup: registerSoup,
+    registerSoupWithSpec: registerSoupWithSpec,
     removeFromSoup: removeFromSoup,
     removeSoup: removeSoup,
     retrieveSoupEntries: retrieveSoupEntries,
@@ -296,6 +314,7 @@ module.exports = {
     upsertSoupEntriesWithExternalId: upsertSoupEntriesWithExternalId,
 
     // Constructors
+    SoupSpec: SoupSpec,
     QuerySpec: QuerySpec,
     SoupIndexSpec: SoupIndexSpec,
     StoreCursor: StoreCursor


### PR DESCRIPTION
Same APIs that we added for ```Cordova```.