### PR TITLE
That was the cause for the 2 alter soup with spec test failures on iOS

### DIFF
--- a/test/SFSmartStoreTestSuite.js
+++ b/test/SFSmartStoreTestSuite.js
@@ -1847,7 +1847,7 @@ SmartStoreTestSuite.prototype.tryAlterSoupWithSpec = function(reIndexData) {
             QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
             return self.closeCursor(cursor);
         })
-        .done(function(param) { 
+        .pipe(function(param) { 
             QUnit.ok(true,"closeCursor ok"); 
             // Alter soup external -> internal
             return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec2, alteredIndexes2, reIndexData);


### PR DESCRIPTION
Android didn't fail because smartstore plugin operations are serialized