### PR TITLE
Bug fix for account editor on Android

### DIFF
--- a/samples/accounteditor/AccountEditor.html
+++ b/samples/accounteditor/AccountEditor.html
@@ -328,7 +328,7 @@ app.views.OfflineToggler = Backbone.View.extend({
 
     toggle: function(event) {
         event.preventDefault();
-        this.model.set("isOnline", !this.model.get("isOnline"))
+        this.model.set("isOnline", !this.model.get("isOnline"));
         if (this.model.get("isOnline")) {
             app.router.navigate("#sync", {trigger:true});        
         }
@@ -417,6 +417,7 @@ app.views.EditAccountPage = Backbone.View.extend({
     },
 
     render: function(eventName) {
+        if (this.model == null) return;
         this.action = (null == this.model.id) ? "Add" : "Edit";
         if (this.action == "Add") { this.model.set({__local__: false, Name:"", Industry:"", Phone:"", LastModifiedDate:"", attributes : { type: "Account"}}); }
         this.backAction = app.router.getLastPage() || "#";
@@ -586,9 +587,18 @@ app.Router = Backbone.StackRouter.extend({
     },
 
     sync: function() {
-        app.localAccounts.fetch();
-        // Show page right away - list will redraw when data comes in
-        this.slidePage(app.syncPage);
+        var that = this;
+        app.localAccounts.fetch({
+            success: function(data) {
+                // Only go to sync screen if there are records to sync
+                if (app.localAccounts.length > 0) {
+                    that.slidePage(app.syncPage);
+                }
+                else {
+                    app.router.navigate(that.getLastPage(), {trigger:true});
+                }
+            }
+        });
     }
 });
 </script>


### PR DESCRIPTION
Emulator starts offline (navigator.onLine is false). And trying to go online was not working.

EditAccountPage was throwing an error when one tried to go online.
EditAccountPage is always watching the app.offlineTracker and before the fix tried to access its model when a toggle takes place.
And it was failing if the model was undefined.

Now it won't fail if it doesn't have a model.

NB:It would be better for it to start/stop watching the app.offlineTracker as it comes into view/leaves view but that change is more involved.

Also sync screen won't be shown if there is nothing to sync.