### PR TITLE
handle the line end for Windows platform

### DIFF
--- a/node/cordovaHelper.js
+++ b/node/cordovaHelper.js
@@ -11,7 +11,7 @@ var getCordovaCliVersion = function() {
         return null;
     }
 
-    var cordovaCliVersion = cordovaVersionResult.stdout.replace('\n', '');
+    var cordovaCliVersion = cordovaVersionResult.stdout.replace(/\r?\n|\r/, '');
     return cordovaCliVersion;
 };
 


### PR DESCRIPTION
line breaks are Carriage Return (CR, \r, on older Macs), Line Feed (LF, \n, on Unices incl. Linux) or CR followed by LF (\r\n, on WinDOS). We need to take care to replace /r/n for Windows 