### PR TITLE
Refresh sync target needs soup name

### DIFF
--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -2828,7 +2828,7 @@ SmartSyncTestSuite.prototype.testRefreshSyncDown = function() {
         .then(function() {
             console.log("## Calling refresh sync down");
             idToName = _.extend(idToName, idToUpdatedName);
-            var target = {type:"refresh", objectType:"Account", fieldlist:["Id", "Name"]};
+            var target = {soupName:soupName, type:"refresh", objectType:"Account", fieldlist:["Id", "Name"]};
             return self.trySyncDown(cache, soupName, idToName, cordova.require("com.salesforce.plugin.smartsync").MERGE_MODE.OVERWRITE, target);
         })
         .then(function() {


### PR DESCRIPTION
The sync has a soup name but the target doesn't get a handle on the sync when running (maybe we could change that)