### PR TITLE
Move to native promises / promise-based smartstore and force clients

### DIFF
--- a/gen/cordova_plugins.js
+++ b/gen/cordova_plugins.js
@@ -20,6 +20,13 @@ module.exports = [
         ]
     },
     {
+        "file": "plugins/com.salesforce/com.salesforce.plugin.smartstore.client.js",
+        "id": "com.salesforce.plugin.smartstore.client",
+        "clobbers": [
+            "navigator.smartstoreClient"
+        ]
+    },
+    {
         "file": "plugins/com.salesforce/com.salesforce.plugin.smartsync.js",
         "id": "com.salesforce.plugin.smartsync",
     },
@@ -34,6 +41,10 @@ module.exports = [
     {
         "file": "plugins/com.salesforce/com.salesforce.util.exec.js",
         "id": "com.salesforce.util.exec"
+    },
+    {
+        "file": "plugins/com.salesforce/com.salesforce.util.promiser.js",
+        "id": "com.salesforce.util.promiser"
     },
     {
         "file": "plugins/com.salesforce/com.salesforce.util.logger.js",

--- a/gen/plugins/com.salesforce/com.salesforce.plugin.smartstore.client.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.smartstore.client.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Version this js was shipped with
+var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
+
+var smartstore = require("com.salesforce.plugin.smartstore");
+var promiser = require("com.salesforce.util.promiser").promiser;
+
+// Promise-based APIs
+var client = new Object();
+client.alterSoup = promiser(smartstore, "alterSoup", "smartstore.client");
+client.alterSoupWithSpec = promiser(smartstore, "alterSoupWithSpec", "smartstore.client");
+client.clearSoup = promiser(smartstore, "clearSoup", "smartstore.client");
+client.closeCursor = promiser(smartstore, "closeCursor", "smartstore.client");
+client.getDatabaseSize = promiser(smartstore, "getDatabaseSize", "smartstore.client");
+client.getSoupIndexSpecs = promiser(smartstore, "getSoupIndexSpecs", "smartstore.client");
+client.getSoupSpec = promiser(smartstore, "getSoupSpec", "smartstore.client");
+client.moveCursorToNextPage = promiser(smartstore, "moveCursorToNextPage", "smartstore.client");
+client.moveCursorToPageIndex = promiser(smartstore, "moveCursorToPageIndex", "smartstore.client");
+client.moveCursorToPreviousPage = promiser(smartstore, "moveCursorToPreviousPage", "smartstore.client");
+client.querySoup = promiser(smartstore, "querySoup", "smartstore.client");
+client.reIndexSoup = promiser(smartstore, "reIndexSoup", "smartstore.client");
+client.registerSoup = promiser(smartstore, "registerSoup", "smartstore.client");
+client.registerSoupWithSpec = promiser(smartstore, "registerSoupWithSpec", "smartstore.client");
+client.removeFromSoup = promiser(smartstore, "removeFromSoup", "smartstore.client");
+client.removeSoup = promiser(smartstore, "removeSoup", "smartstore.client");
+client.retrieveSoupEntries = promiser(smartstore, "retrieveSoupEntries", "smartstore.client");
+client.runSmartQuery = promiser(smartstore, "runSmartQuery", "smartstore.client");
+client.soupExists = promiser(smartstore, "soupExists", "smartstore.client");
+client.upsertSoupEntries = promiser(smartstore, "upsertSoupEntries", "smartstore.client");
+client.upsertSoupEntriesWithExternalId = promiser(smartstore, "upsertSoupEntriesWithExternalId", "smartstore.client");
+
+/**
+ * Part of the module that is public
+ */
+module.exports = client;

--- a/gen/plugins/com.salesforce/com.salesforce.plugin.smartstore.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.smartstore.js
@@ -389,7 +389,7 @@ var moveCursorToNextPage = function (isGlobalStore, cursor, successCB, errorCB) 
     if (checkFirstArg(arguments)) return;
     var newPageIndex = cursor.currentPageIndex + 1;
     if (newPageIndex >= cursor.totalPages) {
-        errorCB(cursor, new Error("moveCursorToNextPage called while on last page"));
+        errorCB(new Error("moveCursorToNextPage called while on last page"));
     } else {
         moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
     }
@@ -399,7 +399,7 @@ var moveCursorToPreviousPage = function (isGlobalStore, cursor, successCB, error
     if (checkFirstArg(arguments)) return;
     var newPageIndex = cursor.currentPageIndex - 1;
     if (newPageIndex < 0) {
-        errorCB(cursor, new Error("moveCursorToPreviousPage called while on first page"));
+        errorCB(new Error("moveCursorToPreviousPage called while on first page"));
     } else {
         moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
     }

--- a/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Version this js was shipped with
+var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
+
+var promiser = function(object, methodName, objectName) {
+    var retfn = function () {
+        var args = Array.from(arguments);
+        return new Promise(function(resolve, reject) {
+            args.push(function() {
+                console.debug("------> Calling successCB for " + objectName + ":" + methodName);
+                try {
+                    resolve.apply(null, arguments);
+                }
+                catch (err) {
+                    console.error("------> Error when calling successCB for " + objectName + ":" + methodName);
+                    console.error(err.stack);
+                }
+            });
+            args.push(function() {
+                console.debug("------> Calling errorCB for " + objectName + ":" + methodName);
+                try {
+                    reject.apply(null, arguments);
+                }
+                catch (err) {
+                    console.error("------> Error when calling errorCB for " + objectName + ":" + methodName);
+                    console.error(err.stack);
+                }
+            });
+            console.debug("-----> Calling " + objectName + ":" + methodName);
+            object[methodName].apply(object, args);
+        });
+    };
+    return retfn;
+};
+
+/**
+ * Part of the module that is public
+ */
+module.exports = {
+    promiser: promiser,
+};

--- a/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
@@ -29,7 +29,8 @@ var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
 
 var promiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = Array.from(arguments);
+        var args = [];
+        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
         return new Promise(function(resolve, reject) {
             args.push(function() {
                 console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins/com.salesforce/com.salesforce.util.promiser.js
@@ -29,8 +29,8 @@ var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
 
 var promiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = [];
-        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
+        var args = Array.prototype.slice.call(arguments);
+
         return new Promise(function(resolve, reject) {
             args.push(function() {
                 console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.smartstore.client.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.smartstore.client.js
@@ -1,0 +1,62 @@
+cordova.define("com.salesforce.plugin.smartstore.client", function(require, exports, module) {
+/*
+ * Copyright (c) 2012-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Version this js was shipped with
+var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
+
+var smartstore = require("com.salesforce.plugin.smartstore");
+var promiser = require("com.salesforce.util.promiser").promiser;
+
+// Promise-based APIs
+var client = new Object();
+client.alterSoup = promiser(smartstore, "alterSoup", "smartstore.client");
+client.alterSoupWithSpec = promiser(smartstore, "alterSoupWithSpec", "smartstore.client");
+client.clearSoup = promiser(smartstore, "clearSoup", "smartstore.client");
+client.closeCursor = promiser(smartstore, "closeCursor", "smartstore.client");
+client.getDatabaseSize = promiser(smartstore, "getDatabaseSize", "smartstore.client");
+client.getSoupIndexSpecs = promiser(smartstore, "getSoupIndexSpecs", "smartstore.client");
+client.getSoupSpec = promiser(smartstore, "getSoupSpec", "smartstore.client");
+client.moveCursorToNextPage = promiser(smartstore, "moveCursorToNextPage", "smartstore.client");
+client.moveCursorToPageIndex = promiser(smartstore, "moveCursorToPageIndex", "smartstore.client");
+client.moveCursorToPreviousPage = promiser(smartstore, "moveCursorToPreviousPage", "smartstore.client");
+client.querySoup = promiser(smartstore, "querySoup", "smartstore.client");
+client.reIndexSoup = promiser(smartstore, "reIndexSoup", "smartstore.client");
+client.registerSoup = promiser(smartstore, "registerSoup", "smartstore.client");
+client.registerSoupWithSpec = promiser(smartstore, "registerSoupWithSpec", "smartstore.client");
+client.removeFromSoup = promiser(smartstore, "removeFromSoup", "smartstore.client");
+client.removeSoup = promiser(smartstore, "removeSoup", "smartstore.client");
+client.retrieveSoupEntries = promiser(smartstore, "retrieveSoupEntries", "smartstore.client");
+client.runSmartQuery = promiser(smartstore, "runSmartQuery", "smartstore.client");
+client.soupExists = promiser(smartstore, "soupExists", "smartstore.client");
+client.upsertSoupEntries = promiser(smartstore, "upsertSoupEntries", "smartstore.client");
+client.upsertSoupEntriesWithExternalId = promiser(smartstore, "upsertSoupEntriesWithExternalId", "smartstore.client");
+
+/**
+ * Part of the module that is public
+ */
+module.exports = client;
+});

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.smartstore.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.smartstore.js
@@ -390,7 +390,7 @@ var moveCursorToNextPage = function (isGlobalStore, cursor, successCB, errorCB) 
     if (checkFirstArg(arguments)) return;
     var newPageIndex = cursor.currentPageIndex + 1;
     if (newPageIndex >= cursor.totalPages) {
-        errorCB(cursor, new Error("moveCursorToNextPage called while on last page"));
+        errorCB(new Error("moveCursorToNextPage called while on last page"));
     } else {
         moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
     }
@@ -400,7 +400,7 @@ var moveCursorToPreviousPage = function (isGlobalStore, cursor, successCB, error
     if (checkFirstArg(arguments)) return;
     var newPageIndex = cursor.currentPageIndex - 1;
     if (newPageIndex < 0) {
-        errorCB(cursor, new Error("moveCursorToPreviousPage called while on first page"));
+        errorCB(new Error("moveCursorToPreviousPage called while on first page"));
     } else {
         moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
     }

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
@@ -30,7 +30,8 @@ var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
 
 var promiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = Array.from(arguments);
+        var args = [];
+        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
         return new Promise(function(resolve, reject) {
             args.push(function() {
                 console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
@@ -30,8 +30,8 @@ var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
 
 var promiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = [];
-        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
+        var args = Array.prototype.slice.call(arguments);
+
         return new Promise(function(resolve, reject) {
             args.push(function() {
                 console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.util.promiser.js
@@ -1,0 +1,68 @@
+cordova.define("com.salesforce.util.promiser", function(require, exports, module) {
+/*
+ * Copyright (c) 2012-present, salesforce.com, inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+ * following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+ * the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Version this js was shipped with
+var SALESFORCE_MOBILE_SDK_VERSION = "5.0.0";
+
+var promiser = function(object, methodName, objectName) {
+    var retfn = function () {
+        var args = Array.from(arguments);
+        return new Promise(function(resolve, reject) {
+            args.push(function() {
+                console.debug("------> Calling successCB for " + objectName + ":" + methodName);
+                try {
+                    resolve.apply(null, arguments);
+                }
+                catch (err) {
+                    console.error("------> Error when calling successCB for " + objectName + ":" + methodName);
+                    console.error(err.stack);
+                }
+            });
+            args.push(function() {
+                console.debug("------> Calling errorCB for " + objectName + ":" + methodName);
+                try {
+                    reject.apply(null, arguments);
+                }
+                catch (err) {
+                    console.error("------> Error when calling errorCB for " + objectName + ":" + methodName);
+                    console.error(err.stack);
+                }
+            });
+            console.debug("-----> Calling " + objectName + ":" + methodName);
+            object[methodName].apply(object, args);
+        });
+    };
+    return retfn;
+};
+
+/**
+ * Part of the module that is public
+ */
+module.exports = {
+    promiser: promiser,
+};
+});

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -216,7 +216,8 @@ cordova.define("com.salesforce.util.promiser", function(require, exports, module
 
     var promiser = function(object, methodName, objectName) {
         var retfn = function () {
-            var args = Array.from(arguments);
+            var args = [];
+            for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
             return new Promise(function(resolve, reject) {
                 args.push(function() {
                     console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -845,7 +845,7 @@ cordova.define("com.salesforce.plugin.smartstore", function (require, exports, m
         if (checkFirstArg(arguments)) return;
         var newPageIndex = cursor.currentPageIndex + 1;
         if (newPageIndex >= cursor.totalPages) {
-            errorCB(cursor, new Error("moveCursorToNextPage called while on last page"));
+            errorCB(new Error("moveCursorToNextPage called while on last page"));
         } else {
             moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
         }
@@ -855,7 +855,7 @@ cordova.define("com.salesforce.plugin.smartstore", function (require, exports, m
         if (checkFirstArg(arguments)) return;
         var newPageIndex = cursor.currentPageIndex - 1;
         if (newPageIndex < 0) {
-            errorCB(cursor, new Error("moveCursorToPreviousPage called while on first page"));
+            errorCB(new Error("moveCursorToPreviousPage called while on first page"));
         } else {
             moveCursorToPageIndex(isGlobalStore, cursor, newPageIndex, successCB, errorCB);
         }

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -1002,6 +1002,9 @@ cordova.define("com.salesforce.plugin.smartstore.client", function(require, expo
     module.exports = client;
 });
 
+// For backward compatibility
+navigator.smartstoreClient = cordova.require("com.salesforce.plugin.smartstore.client");
+
 cordova.define("com.salesforce.plugin.smartsync", function (require, exports, module) {
     var SERVICE = "com.salesforce.smartsync";
 

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -209,6 +209,51 @@ cordova.define("com.salesforce.util.exec", function(require, exports, module) {
     };
 });
 
+/**
+ * Helper function to turn function taking callbacks into a promise
+ */
+cordova.define("com.salesforce.util.promiser", function(require, exports, module) {
+
+    var promiser = function(object, methodName, objectName) {
+        var retfn = function () {
+            var args = Array.from(arguments);
+            return new Promise(function(resolve, reject) {
+                args.push(function() {
+                    console.debug("------> Calling successCB for " + objectName + ":" + methodName);
+                    try {
+                        resolve.apply(null, arguments);
+                    }
+                    catch (err) {
+                        console.error("------> Error when calling successCB for " + objectName + ":" + methodName);
+                        console.error(err.stack);
+                    }
+                });
+                args.push(function() {
+                    console.debug("------> Calling errorCB for " + objectName + ":" + methodName);
+                    try {
+                        reject.apply(null, arguments);
+                    }
+                    catch (err) {
+                        console.error("------> Error when calling errorCB for " + objectName + ":" + methodName);
+                        console.error(err.stack);
+                    }
+                });
+                console.debug("-----> Calling " + objectName + ":" + methodName);
+                object[methodName].apply(object, args);
+            });
+        };
+        return retfn;
+    };
+
+    /**
+     * Part of the module that is public
+     */
+    module.exports = {
+        promiser: promiser,
+    };
+});
+
+
 cordova.define("com.salesforce.plugin.sdkinfo", function(require, exports, module) {
     var SERVICE = "com.salesforce.sdkinfo";
 
@@ -918,6 +963,44 @@ navigator.smartstore = cordova.require("com.salesforce.plugin.smartstore");
 var SoupIndexSpec = navigator.smartstore.SoupIndexSpec;
 var QuerySpec = navigator.smartstore.QuerySpec;
 var StoreCursor = navigator.smartstore.StoreCursor;
+
+/**
+ * SmartStore client with promise-based APIs
+ */
+cordova.define("com.salesforce.plugin.smartstore.client", function(require, exports, module) {
+
+    var smartstore = require("com.salesforce.plugin.smartstore");
+    var promiser = require("com.salesforce.util.promiser").promiser;
+
+    // Promise-based APIs
+    var client = new Object();
+    client.alterSoup = promiser(smartstore, "alterSoup", "smartstore.client");
+    client.alterSoupWithSpec = promiser(smartstore, "alterSoupWithSpec", "smartstore.client");
+    client.clearSoup = promiser(smartstore, "clearSoup", "smartstore.client");
+    client.closeCursor = promiser(smartstore, "closeCursor", "smartstore.client");
+    client.getDatabaseSize = promiser(smartstore, "getDatabaseSize", "smartstore.client");
+    client.getSoupIndexSpecs = promiser(smartstore, "getSoupIndexSpecs", "smartstore.client");
+    client.getSoupSpec = promiser(smartstore, "getSoupSpec", "smartstore.client");
+    client.moveCursorToNextPage = promiser(smartstore, "moveCursorToNextPage", "smartstore.client");
+    client.moveCursorToPageIndex = promiser(smartstore, "moveCursorToPageIndex", "smartstore.client");
+    client.moveCursorToPreviousPage = promiser(smartstore, "moveCursorToPreviousPage", "smartstore.client");
+    client.querySoup = promiser(smartstore, "querySoup", "smartstore.client");
+    client.reIndexSoup = promiser(smartstore, "reIndexSoup", "smartstore.client");
+    client.registerSoup = promiser(smartstore, "registerSoup", "smartstore.client");
+    client.registerSoupWithSpec = promiser(smartstore, "registerSoupWithSpec", "smartstore.client");
+    client.removeFromSoup = promiser(smartstore, "removeFromSoup", "smartstore.client");
+    client.removeSoup = promiser(smartstore, "removeSoup", "smartstore.client");
+    client.retrieveSoupEntries = promiser(smartstore, "retrieveSoupEntries", "smartstore.client");
+    client.runSmartQuery = promiser(smartstore, "runSmartQuery", "smartstore.client");
+    client.soupExists = promiser(smartstore, "soupExists", "smartstore.client");
+    client.upsertSoupEntries = promiser(smartstore, "upsertSoupEntries", "smartstore.client");
+    client.upsertSoupEntriesWithExternalId = promiser(smartstore, "upsertSoupEntriesWithExternalId", "smartstore.client");
+    
+    /**
+     * Part of the module that is public
+     */
+    module.exports = client;
+});
 
 cordova.define("com.salesforce.plugin.smartsync", function (require, exports, module) {
     var SERVICE = "com.salesforce.smartsync";

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -216,8 +216,8 @@ cordova.define("com.salesforce.util.promiser", function(require, exports, module
 
     var promiser = function(object, methodName, objectName) {
         var retfn = function () {
-            var args = [];
-            for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
+            var args = Array.prototype.slice.call(arguments);
+
             return new Promise(function(resolve, reject) {
                 args.push(function() {
                     console.debug("------> Calling successCB for " + objectName + ":" + methodName);

--- a/libs/force.js
+++ b/libs/force.js
@@ -1187,8 +1187,8 @@ var forceJsClient = (function() {
     
     var promiser = function(methodName) {
         var retfn = function () {
-            var args = [];
-            for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
+            var args = Array.prototype.slice.call(arguments);
+
             return new Promise(function(resolve, reject) {
                 args.push(function() {
                     console.debug("------> Calling success handler for force." + methodName);

--- a/libs/force.js
+++ b/libs/force.js
@@ -1187,7 +1187,8 @@ var forceJsClient = (function() {
     
     var promiser = function(methodName) {
         var retfn = function () {
-            var args = Array.from(arguments);
+            var args = [];
+            for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
             return new Promise(function(resolve, reject) {
                 args.push(function() {
                     console.debug("------> Calling success handler for force." + methodName);

--- a/libs/force.js
+++ b/libs/force.js
@@ -1179,3 +1179,85 @@ var force = (function () {
     };
 
 }());
+
+/**
+ * Promise-based APIs
+ */
+var forceJsClient = (function() {
+    
+    var promiser = function(methodName) {
+        var retfn = function () {
+            var args = Array.from(arguments);
+            return new Promise(function(resolve, reject) {
+                args.push(function() {
+                    console.debug("------> Calling success handler for force." + methodName);
+                    try {
+                        resolve.apply(null, arguments);
+                    }
+                    catch (err) {
+                        console.error("------> Error when calling success handler for force." + methodName);
+                        console.error(err.stack);
+                    }
+                });
+                args.push(function() {
+                    console.debug("------> Calling error handler for force." + methodName);
+                    try {
+                        reject.apply(null, arguments);
+                    }
+                    catch (err) {
+                        console.error("------> Error when calling error handler for force." + methodName);
+                        console.error(err.stack);
+                    }
+                });
+                console.debug("-----> Calling force." + methodName);
+                force[methodName].apply(force, args);
+            });
+        };
+        return retfn;
+    };
+
+    var client = new Object();
+
+    client.login = promiser("login");
+    client.request = promiser("request");
+    client.versions = promiser("versions");
+    client.resources = promiser("resources");
+    client.describeGlobal = promiser("describeGlobal");
+    client.metadata = promiser("metadata");
+    client.describe = promiser("describe");
+    client.describeLayout = promiser("describeLayout");
+    client.query = promiser("query");
+    client.queryMore = promiser("queryMore");
+    client.search = promiser("search");
+    client.create = promiser("create");
+    client.update = promiser("update");
+    client.del = promiser("del");
+    client.upsert = promiser("upsert");
+    client.retrieve = promiser("retrieve");
+    client.apexrest = promiser("apexrest");
+    client.chatter = promiser("chatter");
+    client.getPickListValues = promiser("getPickListValues");
+    client.getAttachment = promiser("getAttachment");
+
+    //Files
+    client.ownedFilesList = promiser("ownedFilesList");
+    client.filesInUsersGroups = promiser("filesInUsersGroups");
+    client.filesSharedWithUser = promiser(" filesSharedWithUser");
+    client.fileDetails = promiser("fileDetails");
+    client.batchFileDetails = promiser("batchFileDetails");
+    client.fileShares = promiser("fileShares");
+    client.addFileShare = promiser("addFileShare");
+    client.deleteFileShare = promiser("deleteFileShare");
+
+    // API that dont' return a promise
+    client.init = force.init;
+    client.getUserAgent = force.getUserAgent;
+    client.setUserAgent = force.setUserAgent;
+    client.isAuthenticated = force.isAuthenticated;
+    client.getUserId = force.getUserId;
+    client.discardToken = force.discardToken;
+
+    // The public API
+    return client;
+
+}());

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -63,39 +63,6 @@
     // Default log level: info
     Force.setLogLevel("info");
 
-
-    // Utility Function to turn methods with callbacks into jQuery promises
-    var promiser = function(object, methodName, objectName) {
-        var retfn = function () {
-            var args = Array.from(arguments);
-            return new Promise(function(resolve, reject) {
-                args.push(function() {
-                    Force.console.debug("------> Calling successCB for " + objectName + ":" + methodName);
-                    try {
-                        resolve.apply(null, arguments);
-                    }
-                    catch (err) {
-                        Force.console.error("------> Error when calling successCB for " + objectName + ":" + methodName);
-                        Force.console.error(err.stack);
-                    }
-                });
-                args.push(function() {
-                    Force.console.debug("------> Calling errorCB for " + objectName + ":" + methodName);
-                    try {
-                        reject.apply(null, arguments);
-                    }
-                    catch (err) {
-                        Force.console.error("------> Error when calling errorCB for " + objectName + ":" + methodName);
-                        Force.console.error(err.stack);
-                    }
-                });
-                Force.console.debug("-----> Calling " + objectName + ":" + methodName);
-                object[methodName].apply(object, args);
-            });
-        };
-        return retfn;
-    };
-
     // Private force client with promise-wrapped methods
     var forceJsClient = null;
 
@@ -135,26 +102,15 @@
         forceJsClient.fileDetails = promiser(forceJs, "fileDetails", "forceJsClient");
         forceJsClient.apexrest = promiser(forceJs, "apexrest", "forceJsClient");
 
+        if (cordova && cordova.require("com.salesforce.plugin.smartstore.client"))
+        {
+            smartstoreClient = cordova.require("com.salesforce.plugin.smartstore.client");
+        }
+
         // Exposing outside
         Force.forceJsClient = forceJsClient;
+        Force.smartstoreClient = smartstoreClient;
 
-        if (navigator.smartstore)
-        {
-            smartstoreClient = new Object();
-            smartstoreClient.registerSoup = promiser(navigator.smartstore, "registerSoup", "smartstoreClient");
-            smartstoreClient.upsertSoupEntriesWithExternalId = promiser(navigator.smartstore, "upsertSoupEntriesWithExternalId", "smartstoreClient");
-            smartstoreClient.querySoup = promiser(navigator.smartstore, "querySoup", "smartstoreClient");
-            smartstoreClient.runSmartQuery = promiser(navigator.smartstore, "runSmartQuery", "smartstoreClient");
-            smartstoreClient.moveCursorToNextPage = promiser(navigator.smartstore, "moveCursorToNextPage", "smartstoreClient");
-            smartstoreClient.removeFromSoup = promiser(navigator.smartstore, "removeFromSoup", "smartstoreClient");
-            smartstoreClient.closeCursor = promiser(navigator.smartstore, "closeCursor", "smartstoreClient");
-            smartstoreClient.soupExists = promiser(navigator.smartstore, "soupExists", "smartstoreClient");
-            smartstoreClient.removeSoup = promiser(navigator.smartstore, "removeSoup", "smartstoreClient");
-            smartstoreClient.retrieveSoupEntries = promiser(navigator.smartstore, "retrieveSoupEntries", "smartstoreClient");
-
-            // Exposing outside
-            Force.smartstoreClient = smartstoreClient;
-        }
     };
 
     // Force.Error

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -25,7 +25,7 @@
  *
  */
 
-(function($, _, Backbone, forceJs) {
+(function(_, Backbone, forceJs) {
 
     "use strict";
 
@@ -68,11 +68,11 @@
     var promiser = function(object, methodName, objectName) {
         var retfn = function () {
             var args = Array.from(arguments);
-            var d = new Promise(function(resolve, reject) {
+            return new Promise(function(resolve, reject) {
                 args.push(function() {
                     Force.console.debug("------> Calling successCB for " + objectName + ":" + methodName);
                     try {
-                        resolve.apply(d, arguments);
+                        resolve.apply(null, arguments);
                     }
                     catch (err) {
                         Force.console.error("------> Error when calling successCB for " + objectName + ":" + methodName);
@@ -82,17 +82,16 @@
                 args.push(function() {
                     Force.console.debug("------> Calling errorCB for " + objectName + ":" + methodName);
                     try {
-                        reject.apply(d, arguments);
+                        reject.apply(null, arguments);
                     }
                     catch (err) {
                         Force.console.error("------> Error when calling errorCB for " + objectName + ":" + methodName);
                         Force.console.error(err.stack);
                     }
                 });
+                Force.console.debug("-----> Calling " + objectName + ":" + methodName);
+                object[methodName].apply(object, args);
             });
-            Force.console.debug("-----> Calling " + objectName + ":" + methodName);
-            object[methodName].apply(object, args);
-            return d;
         };
         return retfn;
     };
@@ -1649,4 +1648,4 @@
 
     } // if (!_.isUndefined(Backbone)) {
 })
-.call(this, jQuery, _, window.Backbone, window.force);
+.call(this, _, window.Backbone, window.force);

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -25,7 +25,7 @@
  *
  */
 
-(function(_, Backbone, forceJs) {
+(function(_, Backbone, forceJsClient) {
 
     "use strict";
 
@@ -60,15 +60,9 @@
         }
     };
 
-    // Default log level: info
-    Force.setLogLevel("info");
-
-    // Private force client with promise-wrapped methods
-    var forceJsClient = null;
-
     // Private smartstore client with promise-wrapped methods
     var smartstoreClient = null;
-
+    
     // Helper function to patch user agent
     var patchUserAgent = function(userAgent) {
         var match = /^(SalesforceMobileSDK\/[^\ ]* [^\/]*\/[^\ ]* \([^\)]*\) [^\/]*\/[^ ]* )(Hybrid|Web)(.*$)/.exec(userAgent);
@@ -81,28 +75,23 @@
         }
     };
 
-    forceJs.setUserAgent(patchUserAgent(forceJs.getUserAgent()));
+    /**
+     * Initialize Force
+     * @param params
+     *  logLevel (optional)
+     *  userAgent (optional)
+     */
+    Force.init = function(params) {
+        params = params || {};
 
-    Force.init = function() {
-        forceJsClient = new Object();
-        forceJsClient.impl = forceJs;
-        forceJsClient.create = promiser(forceJs, "create", "forceJsClient");
-        forceJsClient.retrieve = promiser(forceJs, "retrieve", "forceJsClient");
-        forceJsClient.update = promiser(forceJs, "update", "forceJsClient");
-        forceJsClient.del = promiser(forceJs, "del", "forceJsClient");
-        forceJsClient.query = promiser(forceJs, "query", "forceJsClient");
-        forceJsClient.queryMore = promiser(forceJs, "queryMore", "forceJsClient");
-        forceJsClient.search = promiser(forceJs, "search", "forceJsClient");
-        forceJsClient.metadata = promiser(forceJs, "metadata", "forceJsClient");
-        forceJsClient.describe = promiser(forceJs, "describe", "forceJsClient");
-        forceJsClient.describeLayout = promiser(forceJs, "describeLayout", "forceJsClient");
-        forceJsClient.ownedFilesList = promiser(forceJs, "ownedFilesList", "forceJsClient");
-        forceJsClient.filesInUsersGroups = promiser(forceJs, "filesInUsersGroups", "forceJsClient");
-        forceJsClient.filesSharedWithUser = promiser(forceJs, "filesSharedWithUser", "forceJsClient");
-        forceJsClient.fileDetails = promiser(forceJs, "fileDetails", "forceJsClient");
-        forceJsClient.apexrest = promiser(forceJs, "apexrest", "forceJsClient");
+        // Default log level: info
+        Force.setLogLevel(params.logLevel || "info");
+        
+        // The one from forceJsClient patched 
+        forceJsClient.setUserAgent(params.userAgent || patchUserAgent(forceJsClient.getUserAgent()));
 
-        if (cordova && cordova.require("com.salesforce.plugin.smartstore.client"))
+        // Getting a smartstoreclient if availablex
+        if (window.cordova && window.cordova.require("com.salesforce.plugin.smartstore.client"))
         {
             smartstoreClient = cordova.require("com.salesforce.plugin.smartstore.client");
         }
@@ -110,7 +99,6 @@
         // Exposing outside
         Force.forceJsClient = forceJsClient;
         Force.smartstoreClient = smartstoreClient;
-
     };
 
     // Force.Error
@@ -1611,4 +1599,4 @@
 
     } // if (!_.isUndefined(Backbone)) {
 })
-.call(this, _, window.Backbone, window.force);
+.call(this, _, window.Backbone, window.forceJsClient);

--- a/libs/smartsync.js
+++ b/libs/smartsync.js
@@ -742,7 +742,7 @@
                 })
         };
 
-        // Chaining promises that return either a promise or created/upated/read model attributes or null in the case of delete
+        // Chaining promises that return either a promise or created/updated/read model attributes or null in the case of delete
         var promise = null;
         switch(method) {
         case "create": promise = serverCreate(); break;

--- a/samples/userlist/css/ratchet-theme-android.css
+++ b/samples/userlist/css/ratchet-theme-android.css
@@ -1,1 +1,0 @@
-../../../dependencies/ratchet2/ratchet-theme-android.css

--- a/samples/userlist/css/ratchet-theme-android.min.css
+++ b/samples/userlist/css/ratchet-theme-android.min.css
@@ -1,1 +1,0 @@
-../../../dependencies/ratchet2/ratchet-theme-android.min.css

--- a/samples/userlist/css/ratchet-theme-ios.css
+++ b/samples/userlist/css/ratchet-theme-ios.css
@@ -1,1 +1,0 @@
-../../../dependencies/ratchet2/ratchet-theme-ios.css

--- a/samples/userlist/css/ratchet-theme-ios.min.css
+++ b/samples/userlist/css/ratchet-theme-ios.min.css
@@ -1,1 +1,0 @@
-../../../dependencies/ratchet2/ratchet-theme-ios.min.css

--- a/samples/userlist/css/ratchet.min.css
+++ b/samples/userlist/css/ratchet.min.css
@@ -1,1 +1,0 @@
-../../../dependencies/ratchet2/ratchet.min.css

--- a/samples/userlist/index.html
+++ b/samples/userlist/index.html
@@ -14,7 +14,6 @@
    <script src="cordova.js"></script>
    <!-- End Container -->
 
-    <script src="js/jquery.js"></script>
     <script src="js/force.js"></script>
     <script src="js/app.js"></script>
 </head>

--- a/samples/userlist/js/jquery.js
+++ b/samples/userlist/js/jquery.js
@@ -1,1 +1,0 @@
-../../../dependencies/jquery/jquery.js

--- a/test/MockSmartStore.js
+++ b/test/MockSmartStore.js
@@ -128,6 +128,7 @@ var MockSmartStore = (function(window) {
 
         registerSoup: function(soupName, soupSpec, indexSpecs) {
             if (!this.soupExists(soupName)) {
+                if (indexSpecs == null) throw new Error("No indexSpecs provided");
                 this._soups[soupName] = {};
                 this._soupIndexSpecs[soupName] = indexSpecs;
                 this._soupSpecs[soupName] = soupSpec;

--- a/test/SFAbstractSmartStoreTestSuite.js
+++ b/test/SFAbstractSmartStoreTestSuite.js
@@ -36,6 +36,8 @@ if (typeof AbstractSmartStoreTestSuite === 'undefined') {
 var AbstractSmartStoreTestSuite = function (module, defaultSoupIndexes) {
     SFTestSuite.call(this, module);
     this.defaultSoupIndexes = defaultSoupIndexes;
+    this.smartstore = cordova.require("com.salesforce.plugin.smartstore");
+    this.smartstoreClient = cordova.require("com.salesforce.plugin.smartstore.client");
 };
 
 // We are sub-classing SFTestSuite
@@ -56,46 +58,12 @@ AbstractSmartStoreTestSuite.prototype.runTest= function (methName) {
             });
 };
 
-/**
- * Helper methods to do smartstore operations using promises
- */
-AbstractSmartStoreTestSuite.prototype.alterSoup = promiser(navigator.smartstore, "alterSoup");
-AbstractSmartStoreTestSuite.prototype.alterSoupWithSpec = promiser(navigator.smartstore, "alterSoupWithSpec");
-AbstractSmartStoreTestSuite.prototype.clearSoup = promiser(navigator.smartstore, "clearSoup");
-AbstractSmartStoreTestSuite.prototype.closeCursor = promiser(navigator.smartstore, "closeCursor");
-AbstractSmartStoreTestSuite.prototype.getDatabaseSize = promiser(navigator.smartstore, "getDatabaseSize");
-AbstractSmartStoreTestSuite.prototype.getSoupIndexSpecs = promiser(navigator.smartstore, "getSoupIndexSpecs");
-AbstractSmartStoreTestSuite.prototype.getSoupSpec = promiser(navigator.smartstore, "getSoupSpec");
-AbstractSmartStoreTestSuite.prototype.moveCursorToNextPage = promiser(navigator.smartstore, "moveCursorToNextPage");
-AbstractSmartStoreTestSuite.prototype.moveCursorToPreviousPage = promiser(navigator.smartstore, "moveCursorToPreviousPage");
-AbstractSmartStoreTestSuite.prototype.querySoup = promiser(navigator.smartstore, "querySoup");
-AbstractSmartStoreTestSuite.prototype.reIndexSoup = promiser(navigator.smartstore, "reIndexSoup");
-AbstractSmartStoreTestSuite.prototype.registerSoup = promiser(navigator.smartstore, "registerSoup");
-AbstractSmartStoreTestSuite.prototype.registerSoupWithSpec = promiser(navigator.smartstore, "registerSoupWithSpec");
-AbstractSmartStoreTestSuite.prototype.removeFromSoup = promiser(navigator.smartstore, "removeFromSoup");
-AbstractSmartStoreTestSuite.prototype.removeSoup = promiser(navigator.smartstore, "removeSoup");
-AbstractSmartStoreTestSuite.prototype.retrieveSoupEntries = promiser(navigator.smartstore, "retrieveSoupEntries");
-AbstractSmartStoreTestSuite.prototype.runSmartQuery = promiser(navigator.smartstore, "runSmartQuery");
-AbstractSmartStoreTestSuite.prototype.soupExists = promiser(navigator.smartstore, "soupExists");
-AbstractSmartStoreTestSuite.prototype.upsertEntriesToSoupWithExternalIdPath = promiser(navigator.smartstore, "upsertSoupEntriesWithExternalId");
-AbstractSmartStoreTestSuite.prototype.upsertSoupEntries = promiser(navigator.smartstore, "upsertSoupEntries");
-
-AbstractSmartStoreTestSuite.prototype.alterSoupNoAssertion = promiser(navigator.smartstore, "alterSoup", true);
-AbstractSmartStoreTestSuite.prototype.clearSoupNoAssertion = promiser(navigator.smartstore, "clearSoup", true);
-AbstractSmartStoreTestSuite.prototype.getSoupIndexSpecsNoAssertion = promiser(navigator.smartstore, "getSoupIndexSpecs", true);
-AbstractSmartStoreTestSuite.prototype.moveCursorToNextPageNoAssertion = promiser(navigator.smartstore, "moveCursorToNextPage", true);
-AbstractSmartStoreTestSuite.prototype.moveCursorToPreviousPageNoAssertion = promiser(navigator.smartstore, "moveCursorToPreviousPage", true);
-AbstractSmartStoreTestSuite.prototype.querySoupNoAssertion = promiser(navigator.smartstore, "querySoup", true);
-AbstractSmartStoreTestSuite.prototype.reIndexSoupNoAssertion = promiser(navigator.smartstore, "reIndexSoup", true);
-AbstractSmartStoreTestSuite.prototype.registerSoupNoAssertion = promiser(navigator.smartstore, "registerSoup", true);
-AbstractSmartStoreTestSuite.prototype.upsertSoupEntriesNoAssertion = promiser(navigator.smartstore, "upsertSoupEntries", true);
-
 AbstractSmartStoreTestSuite.prototype.registerDefaultSoup = function() {
-    return this.registerSoup(this.defaultSoupName, this.defaultSoupIndexes);
+    return this.smartstoreClient.registerSoup(this.defaultSoupName, this.defaultSoupIndexes);
 };
 
 AbstractSmartStoreTestSuite.prototype.removeDefaultSoup = function() {
-    return this.removeSoup(this.defaultSoupName);
+    return this.smartstoreClient.removeSoup(this.defaultSoupName);
 };
 
 /**
@@ -104,20 +72,20 @@ AbstractSmartStoreTestSuite.prototype.removeDefaultSoup = function() {
 AbstractSmartStoreTestSuite.prototype.removeAndRecreateSoup = function(soupName, soupIndexes) {
     var self = this;
     // Start clean
-    return self.removeSoup(soupName)
+    return self.smartstoreClient.removeSoup(soupName)
         .then(function() {
             // Check soup does not exist
-            return self.soupExists(soupName);
+            return self.smartstoreClient.soupExists(soupName);
         })
         .then(function(exists) {
             QUnit.equals(exists, false, "soup should not already exist");
             // Create soup
-            return self.registerSoup(soupName, soupIndexes);
+            return self.smartstoreClient.registerSoup(soupName, soupIndexes);
         })
         .then(function(soupName2) {
             QUnit.equals(soupName2,soupName,"registered soup OK");
             // Check soup now exists
-            return self.soupExists(soupName);
+            return self.smartstoreClient.soupExists(soupName);
         })
         .then(function(exists2) {
             QUnit.equals(exists2, true, "soup should now exist");
@@ -131,7 +99,7 @@ AbstractSmartStoreTestSuite.prototype.removeAndRecreateSoup = function(soupName,
 AbstractSmartStoreTestSuite.prototype.addGeneratedEntriesToSoup = function(soupName, nEntries) {
     console.log("In addGeneratedEntriesToSoup: " + soupName + " nEntries=" + nEntries);
     var entries = this.createGeneratedEntries(nEntries);
-    return this.upsertSoupEntries(soupName, entries);
+    return this.smartstoreClient.upsertSoupEntries(soupName, entries);
 };
 
 /**
@@ -182,12 +150,12 @@ AbstractSmartStoreTestSuite.prototype.addGeneratedEntriesToTestSoup = function(n
  */
 AbstractSmartStoreTestSuite.prototype.addEntriesToTestSoup = function(entries) {
     console.log("In addEntriesToTestSoup: entries.length=" + entries.length);
-    return this.upsertSoupEntries(this.defaultSoupName,entries);
+    return this.smartstoreClient.upsertSoupEntries(this.defaultSoupName,entries);
 };
     
 AbstractSmartStoreTestSuite.prototype.addEntriesWithExternalIdToTestSoup = function(entries, externalIdPath) {
     console.log("In addEntriesWithExternalIdToTestSoup: entries.length=" + entries.length);
-    return this.upsertEntriesToSoupWithExternalIdPath(this.defaultSoupName, entries, externalIdPath);
+    return this.smartstoreClient.upsertSoupEntriesWithExternalId(this.defaultSoupName, entries, externalIdPath);
 };
 
 }

--- a/test/SFAbstractSmartStoreTestSuite.js
+++ b/test/SFAbstractSmartStoreTestSuite.js
@@ -50,7 +50,7 @@ AbstractSmartStoreTestSuite.prototype.runTest= function (methName) {
     var self = this;
     this.defaultSoupName = "soupFor" + methName;
     self.removeAndRecreateSoup(this.defaultSoupName, this.defaultSoupIndexes)
-        .done(
+        .then(
             function() {
                 self[methName]();
             });
@@ -105,21 +105,21 @@ AbstractSmartStoreTestSuite.prototype.removeAndRecreateSoup = function(soupName,
     var self = this;
     // Start clean
     return self.removeSoup(soupName)
-        .pipe(function() {
+        .then(function() {
             // Check soup does not exist
             return self.soupExists(soupName);
         })
-        .pipe(function(exists) {
+        .then(function(exists) {
             QUnit.equals(exists, false, "soup should not already exist");
             // Create soup
             return self.registerSoup(soupName, soupIndexes);
         })
-        .pipe(function(soupName2) {
+        .then(function(soupName2) {
             QUnit.equals(soupName2,soupName,"registered soup OK");
             // Check soup now exists
             return self.soupExists(soupName);
         })
-        .done(function(exists2) {
+        .then(function(exists2) {
             QUnit.equals(exists2, true, "soup should now exist");
         });
 }

--- a/test/SFSDKInfoTestSuite.js
+++ b/test/SFSDKInfoTestSuite.js
@@ -56,7 +56,7 @@ SDKInfoTestSuite.prototype.testGetInfo = function()  {
     var self = this;
 
     self.getInfo()
-        .done(function(sdkInfo) {
+        .then(function(sdkInfo) {
             // sdkVersion
         	QUnit.ok(sdkInfo.sdkVersion.indexOf("5.0") == 0, "expected different sdk version");
             // appName

--- a/test/SFSDKInfoTestSuite.js
+++ b/test/SFSDKInfoTestSuite.js
@@ -45,6 +45,7 @@ SDKInfoTestSuite.prototype.constructor = SDKInfoTestSuite;
 /**
  * Helper method to do sdk info operations using promises
  */
+var promiser = cordova.require("com.salesforce.util.promiser").promiser;
 SDKInfoTestSuite.prototype.getInfo = promiser(cordova.require("com.salesforce.plugin.sdkinfo"), "getInfo");
 
 /** 

--- a/test/SFSmartStoreLoadTestSuite.js
+++ b/test/SFSmartStoreLoadTestSuite.js
@@ -168,7 +168,7 @@ SmartStoreLoadTestSuite.prototype.testAddAndRetrieveManyEntries  = function() {
 				retrievedIds.push(addedEntries[i]._soupEntryId);
 			}
 					
-			return self.retrieveSoupEntries(self.defaultSoupName, retrievedIds);
+			return self.smartstoreClient.retrieveSoupEntries(self.defaultSoupName, retrievedIds);
         })
     .then(function(retrievedEntries) {
 		QUnit.equal(retrievedEntries.length, addedEntries.length,"verify retrieved matches added");
@@ -199,12 +199,12 @@ SmartStoreLoadTestSuite.prototype.upsertQueryEntries = function(batch) {
     
     return self.addEntriesToTestSoup(entries)
         .then(function(updatedentries) {
-            var querySpec = navigator.smartstore.buildAllQuerySpec("key",null, self.QUERY_PAGE_SIZE);
-            return self.querySoup(self.defaultSoupName, querySpec);
+            var querySpec = self.smartstore.buildAllQuerySpec("key",null, self.QUERY_PAGE_SIZE);
+            return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
         })
         .then(function(cursor) {
             QUnit.equal(cursor.totalPages, Math.ceil(endKey/self.QUERY_PAGE_SIZE))
-            return self.closeCursor(cursor);
+            return self.smartstoreClient.closeCursor(cursor);
         })
         .then(function() {
             if (batch < self.NUMBER_BATCHES - 1) {
@@ -307,11 +307,11 @@ SmartStoreLoadTestSuite.prototype.testUpsertConcurrentEntries = function() {
         QUnit.equal(upsertResults.length, numInsertIterations, 'Invalid number of upsert results.');
         var lastEntryBatch = self.getLastUpsertBatch(upsertResults);
                                     
-        var querySpec = navigator.smartstore.buildAllQuerySpec("key", null, upsertResults.length);
-        self.querySoup(self.defaultSoupName, querySpec)
+        var querySpec = self.smartstore.buildAllQuerySpec("key", null, upsertResults.length);
+        self.smartstoreClient.querySoup(self.defaultSoupName, querySpec)
             .then(function(cursor) {
                 self.compareRetrievedEntriesWithLastEntryBatch(cursor.currentPageOrderedEntries, lastEntryBatch);
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function() {
                 self.finalizeTest();

--- a/test/SFSmartStoreTestSuite.js
+++ b/test/SFSmartStoreTestSuite.js
@@ -73,7 +73,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var initialSize;
 
         // Start clean
-        self.getDatabaseSize()
+        self.smartstoreClient.getDatabaseSize()
             .then(function(size) {
                 QUnit.ok(size > 0,"check getDatabaseSize result: " + size);
                 initialSize = size;
@@ -81,7 +81,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function(entries) {
                 QUnit.equal(entries.length, 2000, "check addGeneratedEntriesToTestSoup result");
-                return self.getDatabaseSize();
+                return self.smartstoreClient.getDatabaseSize();
             })
             .then(function(size) {
                 QUnit.ok(size > initialSize,"check getDatabaseSize result: " + size);
@@ -101,62 +101,62 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var REGULAR_STORE = false;
 
         // Start clean
-        Promise.all([self.removeSoup(REGULAR_STORE, soupName),
-                     self.removeSoup(GLOBAL_STORE, soupName)])
+        Promise.all([self.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
+                     self.smartstoreClient.removeSoup(GLOBAL_STORE, soupName)])
             .then(function() {
                 // Check soup does not exist in either stores
-                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
-                                    self.soupExists(GLOBAL_STORE, soupName)]);
+                return Promise.all([self.smartstoreClient.soupExists(REGULAR_STORE, soupName),
+                                    self.smartstoreClient.soupExists(GLOBAL_STORE, soupName)]);
             })
             .then(function(result) {
                 var exists = result[0], existsGlobal = result[1];
                 QUnit.equals(exists, false, "soup should not already exist in regular store");
                 QUnit.equals(existsGlobal, false, "soup should not already exist in global store");
                 // Create soup in global store
-                return self.registerSoup(GLOBAL_STORE, soupName, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(GLOBAL_STORE, soupName, self.smartstoreClient.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK in global store");
                 // Check soup exist only in global store
-                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
-                                    self.soupExists(GLOBAL_STORE, soupName)]);
+                return Promise.all([self.smartstoreClient.soupExists(REGULAR_STORE, soupName),
+                                    self.smartstoreClient.soupExists(GLOBAL_STORE, soupName)]);
             })
             .then(function(result) {
                 var exists = result[0], existsGlobal = result[1];
                 QUnit.equals(exists, false, "soup should not exist in regular store");
                 QUnit.equals(existsGlobal, true, "soup should now exist in global store");
                 // Create soup in regular store
-                return self.registerSoup(REGULAR_STORE, soupName, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(REGULAR_STORE, soupName, self.smartstoreClient.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK in regular store");
                 // Check soup exist only in both stores
-                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
-                                    self.soupExists(GLOBAL_STORE, soupName)]);
+                return Promise.all([self.smartstoreClient.soupExists(REGULAR_STORE, soupName),
+                                    self.smartstoreClient.soupExists(GLOBAL_STORE, soupName)]);
             })
             .then(function(result) {
                 var exists = result[0], existsGlobal = result[1];
                 QUnit.equals(exists, true, "soup should now exist in regular store");
                 QUnit.equals(existsGlobal, true, "soup should exist in global store");
                 // Remove soup from global store
-                return self.removeSoup(GLOBAL_STORE, soupName);
+                return self.smartstoreClient.removeSoup(GLOBAL_STORE, soupName);
             })
             .then(function() {
                 // Check soup exist only in regular store
-                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
-                                    self.soupExists(GLOBAL_STORE, soupName)]);
+                return Promise.all([self.smartstoreClient.soupExists(REGULAR_STORE, soupName),
+                                    self.smartstoreClient.soupExists(GLOBAL_STORE, soupName)]);
             })
             .then(function(result) {
                 var exists = result[0], existsGlobal = result[1];
                 QUnit.equals(exists, true, "soup should still exist in regular store");
                 QUnit.equals(existsGlobal, false, "soup should no longer exist in global store");
                 // Remove soup from regular store
-                return self.removeSoup(REGULAR_STORE, soupName);
+                return self.smartstoreClient.removeSoup(REGULAR_STORE, soupName);
             })
             .then(function() {
                 // Check soup no longer exist in either store
-                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
-                                    self.soupExists(GLOBAL_STORE, soupName)]);
+                return Promise.all([self.smartstoreClient.soupExists(REGULAR_STORE, soupName),
+                                    self.smartstoreClient.soupExists(GLOBAL_STORE, soupName)]);
             })
             .then(function(result) {
                 var exists = result[0], existsGlobal = result[1];
@@ -176,34 +176,34 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Start clean
-        self.removeSoup(soupName)
+        self.smartstoreClient.removeSoup(soupName)
             .then(function() {
                 // Check soup does not exist
-                return self.soupExists(soupName);
+                return self.smartstoreClient.soupExists(soupName);
             })
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should not already exist");
                 // Create soup
-                return self.registerSoup(soupName, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(soupName, self.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK");
                 // Check soup now exists
-                return self.soupExists(soupName);
-            }, function(err) {QUnit.ok(false,"self.registerSoup failed " + err);})
+                return self.smartstoreClient.soupExists(soupName);
+            }, function(err) {QUnit.ok(false,"self.smartstoreClient.registerSoup failed " + err);})
             .then(function(exists) {
                 QUnit.equals(exists, true, "soup should now exist");
                 // Attempt to register the same soup again
-                return self.registerSoup(soupName, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(soupName, self.defaultSoupIndexes);
             })
             .then(function(soupName3) {
                 QUnit.equals(soupName3,soupName,"re-registered existing soup OK");
                 // Remove soup
-                return self.removeSoup(soupName);
+                return self.smartstoreClient.removeSoup(soupName);
             }, function(err) {QUnit.ok(false,"re-registering existing soup failed " + err);})
             .then(function() {
                 // Check soup no longer exists
-                return self.soupExists(soupName);
+                return self.smartstoreClient.soupExists(soupName);
             })
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should no longer exist");
@@ -221,21 +221,21 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Start clean
-        self.removeSoup(soupName)
+        self.smartstoreClient.removeSoup(soupName)
             .then(function() {
                 // Check soup does not exist
-                return self.soupExists(soupName);
+                return self.smartstoreClient.soupExists(soupName);
             })
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should not already exist");
                 // Create soup
-                return self.registerSoupWithSpec({name:soupName, features:["externalStorage"]}, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoupWithSpec({name:soupName, features:["externalStorage"]}, self.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK");
                 // Check soup now exists
-                return self.soupExists(soupName);
-            }, function(err) {QUnit.ok(false,"self.registerSoupWithSpec failed " + err);})
+                return self.smartstoreClient.soupExists(soupName);
+            }, function(err) {QUnit.ok(false,"self.smartstoreClient.registerSoupWithSpec failed " + err);})
             .then(function(exists) {
                 QUnit.equals(exists, true, "soup should now exist");
                 // Check soup spec
@@ -243,11 +243,11 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function() {
                 // Remove soup
-                return self.removeSoup(soupName);
-            }, function(err) {QUnit.ok(false,"self.getSoupSpec failed " + err);})
+                return self.smartstoreClient.removeSoup(soupName);
+            }, function(err) {QUnit.ok(false,"self.smartstoreClient.getSoupSpec failed " + err);})
             .then(function() {
                 // Check soup no longer exists
-                return self.soupExists(soupName);
+                return self.smartstoreClient.soupExists(soupName);
             })
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should no longer exist");
@@ -264,10 +264,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var soupName = null;//intentional bogus soupName
         var self = this;
 
-        self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes)
-            .then(function(soupName2) {
-                self.setAssertionFailed("registerSoup should fail with bogus soupName " + soupName2);
-            })
+        self.smartstoreClient.registerSoup(soupName, self.defaultSoupIndexes)
             .catch(function() {            
                 QUnit.ok(true,"registerSoup should fail with bogus soupName");
                 self.finalizeTest();
@@ -285,18 +282,15 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Start clean
-        self.removeSoup(soupName)
+        self.smartstoreClient.removeSoup(soupName)
             .then(function() {
                 // Check soup does not exist
-                return self.soupExists(soupName);
+                return self.smartstoreClient.soupExists(soupName);
             })
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should not already exist");
                 // Create soup
-                return self.registerSoupNoAssertion(soupName, []);
-            })
-            .then(function(soupName2) {
-                self.setAssertionFailed("registerSoup should fail with bogus indices " + soupName2);
+                return self.smartstoreClient.registerSoup(soupName, []);
             })
             .catch(function() {            
                 QUnit.ok(true,"registerSoup should fail with bogus indices");
@@ -354,14 +348,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                     entry.updatedField = "Mister Toast " + i;
                 }
                 var externalIdPath = self.defaultSoupIndexes[0].path;
-                return self.upsertEntriesToSoupWithExternalIdPath(self.defaultSoupName, entries2, externalIdPath);
+                return self.smartstoreClient.upsertSoupEntriesWithExternalId(self.defaultSoupName, entries2, externalIdPath);
             })
             .then(function(entries3) {
                 QUnit.equal(entries3.length, 16);
                 
                 // Now, query the soup for all entries, and make sure that we have only 16.
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", null, 25);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name", null, 25);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 16, "Are totalEntries correct?");
@@ -374,7 +368,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(orderedEntries[15]._soupEntryId, 16, "Is the last soup entry ID correct?");
                 QUnit.equal(orderedEntries[15].updatedField, "Mister Toast 15", "Is the last updated field correct?");
                 
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -392,10 +386,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
         var entries = [{a:1},{a:2},{a:3}];
         
-        self.upsertSoupEntriesNoAssertion("nonexistentSoup", entries)
-            .then(function(upsertedEntries) {
-                self.setAssertionFailed("upsertSoupEntries should fail with nonexistent soup ");
-            })
+        self.smartstoreClient.upsertSoupEntries("nonexistentSoup", entries)
             .catch(function() {            
                 QUnit.ok(true,"upsertSoupEntries should fail with nonexistent soup");
                 self.finalizeTest();
@@ -418,7 +409,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 soupEntry0Id = entries[0]._soupEntryId;
                 soupEntry2Id = entries[2]._soupEntryId;
                 
-                return self.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id]);
+                return self.smartstoreClient.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id]);
             })
             .then(function(retrievedEntries) {
                 QUnit.equal(retrievedEntries.length, 2);
@@ -451,18 +442,18 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                     soupEntryIds.push(entry._soupEntryId);
                 }
                 
-                return self.removeFromSoup(self.defaultSoupName, soupEntryIds);
+                return self.smartstoreClient.removeFromSoup(self.defaultSoupName, soupEntryIds);
             })
             .then(function(status) {
                 QUnit.equal(status, "OK", "removeFromSoup OK");
                 
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -480,48 +471,48 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3);
-                var querySpecForRemove = navigator.smartstore.buildExactQuerySpec("Name", "Robot");
-                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+                var querySpecForRemove = self.smartstore.buildExactQuerySpec("Name", "Robot");
+                return self.smartstoreClient.removeFromSoup(self.defaultSoupName, querySpecForRemove);
             })
             .then(function(status) {
                 QUnit.equal(status, "OK", "removeFromSoup OK");
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Id", "ascending");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify second entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                var querySpecForRemove = navigator.smartstore.buildLikeQuerySpec("Name", "%Stella%");
-                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+                var querySpecForRemove = self.smartstore.buildLikeQuerySpec("Name", "%Stella%");
+                return self.smartstoreClient.removeFromSoup(self.defaultSoupName, querySpecForRemove);
             })
             .then(function(status) {
                 QUnit.equal(status, "OK", "removeFromSoup OK");
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Id", "ascending");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check currentPageOrderedEntries");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify only entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                var querySpecForRemove = navigator.smartstore.buildAllQuerySpec("Name");
-                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+                var querySpecForRemove = self.smartstore.buildAllQuerySpec("Name");
+                return self.smartstoreClient.removeFromSoup(self.defaultSoupName, querySpecForRemove);
             })
             .then(function(status) {
                 QUnit.equal(status, "OK", "removeFromSoup OK");
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Id");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Id");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check currentPageOrderedEntries");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -539,8 +530,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3);
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name","Robot");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
@@ -548,12 +539,12 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 1, "wrong number of results");
                 QUnit.equal(cursor.currentPageOrderedEntries[0]["Name"], "Robot", "wrong name");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 // Now querying with select paths
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot",null,null,null,["Name", "Id"]);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name","Robot",null,null,null,["Name", "Id"]);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
@@ -562,7 +553,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(nEntries, 1, "wrong number of results");
                 QUnit.equal(cursor.currentPageOrderedEntries[0][0], "Robot", "wrong name");
                 QUnit.equal(cursor.currentPageOrderedEntries[0][1], "00300C", "wrong id");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -582,8 +573,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             then(function(entries) {
                 QUnit.equal(entries.length, 3);
                 
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending");       
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name", "descending");       
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
@@ -592,12 +583,12 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify second entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[2].Name,"Pro Bono Bonobo","verify third entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 // Now querying with select paths
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending", null, ["Name", "Id"]);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name", "descending", null, ["Name", "Id"]);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
@@ -610,7 +601,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300C","verify second entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[2][1],"00300B","verify third entry");
 
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -628,9 +619,9 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup().
             then(function(entries) {
                 QUnit.equal(entries.length, 3);
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name");
+                var querySpec = self.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name");
                 // should match 00300A and 00300B but sort by name
-                return self.querySoup(self.defaultSoupName, querySpec);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
@@ -641,12 +632,12 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Todd Stellanova","verify last entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Id,"00300A","verify last entry");
 
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 // Now querying with select paths
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name", ["Name", "Id"]);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name", ["Name", "Id"]);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
@@ -657,7 +648,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300B","verify first entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300A","verify second entry");
 
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -677,12 +668,9 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(entries.length, 3);
                 
                 //query on a nonexistent index
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");             
+                var querySpec = self.smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");             
                 
-                return self.querySoupNoAssertion(self.defaultSoupName, querySpec);
-            })
-            .then(function(cursor) {
-                self.setAssertionFailed("querySoup with bogus querySpec should fail");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .catch(function(param) { 
                 QUnit.ok(true,"querySoup with bogus querySpec should fail");
@@ -702,15 +690,15 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 QUnit.equal(entries.length, 3);
                 //keep in sync with stuffTestSoup
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("Name",null,"Robot");              
+                var querySpec = self.smartstore.buildRangeQuerySpec("Name",null,"Robot");              
 
-                return self.querySoup(self.defaultSoupName, querySpec);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 2, "nEntries matches endKey");
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify last entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -729,15 +717,15 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 QUnit.equal(entries.length, 3);
                 //keep in sync with stuffTestSoup
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("Name","Robot",null);              
+                var querySpec = self.smartstore.buildRangeQuerySpec("Name","Robot",null);              
 
-                return self.querySoup(self.defaultSoupName, querySpec);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 2, "nEntries matches beginKey");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Robot","verify first entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -773,28 +761,28 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
             .then(function(entries) {
                 QUnit.equal(entries.length, NUM_ENTRIES);
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 checkPage(cursor, 0);
-                return self.moveCursorToNextPage(cursor);
+                return self.smartstoreClient.moveCursorToNextPage(cursor);
             })
             .then(function(cursor) {
                 checkPage(cursor, 1);
-                return self.moveCursorToNextPage(cursor);
+                return self.smartstoreClient.moveCursorToNextPage(cursor);
             })
             .then(function(cursor) {
                 checkPage(cursor, 2);
-                return self.moveCursorToPreviousPage(cursor);
+                return self.smartstoreClient.moveCursorToPreviousPage(cursor);
             })
             .then(function(cursor) {
                 checkPage(cursor, 1);
-                return self.moveCursorToNextPage(cursor);
+                return self.smartstoreClient.moveCursorToNextPage(cursor);
             })
             .then(function(cursor) {
                 checkPage(cursor, 2);
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -817,17 +805,17 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
             .then(function(entries) {
                 QUnit.equal(entries.length, NUM_ENTRIES);
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(c) {
                 cursor = c;
                 QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-                return self.moveCursorToPreviousPageNoAssertion(cursor);
+                return self.smartstoreClient.moveCursorToPreviousPage(cursor);
             })
             .catch(function(error) {
                 QUnit.ok(error.message.indexOf("moveCursorToPreviousPage") == 0, "error should be about moveCursorToPreviousPage")
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -851,21 +839,21 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
             .then(function(entries) {
                 QUnit.equal(entries.length, NUM_ENTRIES);
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-                return self.moveCursorToNextPage(cursor);
+                return self.smartstoreClient.moveCursorToNextPage(cursor);
             })
             .then(function(c) {
                 cursor = c;
                 QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex correct");
-                return self.moveCursorToNextPageNoAssertion(cursor);
+                return self.smartstoreClient.moveCursorToNextPage(cursor);
             })
             .catch(function(error) {
                 QUnit.ok(error.message.indexOf("moveCursorToNextPage") == 0, "error should be about moveCursorToNextPage");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) {
                  QUnit.ok(true,"closeCursor ok"); 
@@ -907,7 +895,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var selectPaths = ["x","y"];
 
         // Exact query with all args
-        var query =  navigator.smartstore.buildExactQuerySpec(path,matchKey,pageSize,order,orderPath,selectPaths);
+        var query =  self.smartstore.buildExactQuerySpec(path,matchKey,pageSize,order,orderPath,selectPaths);
         QUnit.equal(query.queryType,"exact","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.matchKey,matchKey,"check matchKey");
@@ -917,7 +905,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
 
         // Exact query with min args
-        query = navigator.smartstore.buildExactQuerySpec(path,matchKey);
+        query = self.smartstore.buildExactQuerySpec(path,matchKey);
         QUnit.equal(query.queryType,"exact","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.matchKey,matchKey,"check matchKey");
@@ -927,7 +915,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.ok(query.selectPaths == null,"check selectPaths");    
         
         // Range query with all args
-        query = navigator.smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize,orderPath,selectPaths);
+        query = self.smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize,orderPath,selectPaths);
         QUnit.equal(query.queryType,"range","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.beginKey,beginKey,"check beginKey");
@@ -938,7 +926,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
 
         // Range query with min args
-        query = navigator.smartstore.buildRangeQuerySpec(path,beginKey);
+        query = self.smartstore.buildRangeQuerySpec(path,beginKey);
         QUnit.equal(query.queryType,"range","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.beginKey,beginKey,"check beginKey");
@@ -949,7 +937,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.ok(query.selectPaths == null,"check selectPaths");    
         
         // Like query with all args
-        query = navigator.smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize,orderPath,selectPaths);
+        query = self.smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize,orderPath,selectPaths);
         QUnit.equal(query.queryType,"like","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.likeKey,beginKey,"check likeKey");
@@ -959,7 +947,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
         
         // Like query with min args
-        query = navigator.smartstore.buildLikeQuerySpec(path,beginKey);
+        query = self.smartstore.buildLikeQuerySpec(path,beginKey);
         QUnit.equal(query.queryType,"like","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.likeKey,beginKey,"check likeKey");
@@ -969,7 +957,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.ok(query.selectPaths == null,"check selectPaths");    
         
         // All query with all args
-        query = navigator.smartstore.buildAllQuerySpec(path,order,pageSize,selectPaths);
+        query = self.smartstore.buildAllQuerySpec(path,order,pageSize,selectPaths);
         QUnit.equal(query.queryType,"range","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.orderPath,path,"check orderPath");
@@ -979,7 +967,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
 
         // All query with min args
-        query = navigator.smartstore.buildAllQuerySpec(path);
+        query = self.smartstore.buildAllQuerySpec(path);
         QUnit.equal(query.queryType,"range","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.orderPath,path,"check orderPath");
@@ -989,7 +977,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.ok(query.selectPaths == null,"check selectPaths");    
 
         // Match query with all args
-        query = navigator.smartstore.buildMatchQuerySpec(path, matchKey, order, pageSize, orderPath, selectPaths);
+        query = self.smartstore.buildMatchQuerySpec(path, matchKey, order, pageSize, orderPath, selectPaths);
         QUnit.equal(query.queryType,"match","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.matchKey,matchKey,"check matchKey");
@@ -999,7 +987,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
         
         // Match query with min args
-        query = navigator.smartstore.buildMatchQuerySpec(path, matchKey);
+        query = self.smartstore.buildMatchQuerySpec(path, matchKey);
         QUnit.equal(query.queryType,"match","check queryType");
         QUnit.equal(query.indexPath,path,"check indexPath");
         QUnit.equal(query.matchKey,matchKey,"check matchKey");
@@ -1021,19 +1009,19 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildLikeQuerySpec("Name","Todd%");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 // Now querying with select paths
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%", null, null, null, ["Name", "Id"]);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildLikeQuerySpec("Name","Todd%", null, null, null, ["Name", "Id"]);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
@@ -1042,7 +1030,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Todd Stellanova","verify second entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300A","verify second entry");
 
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1061,14 +1049,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%Stellanova");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildLikeQuerySpec("Name","%Stellanova");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1086,14 +1074,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%ono%");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildLikeQuerySpec("Name","%ono%");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1116,56 +1104,56 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"description", type:"full_text"}, {path:"colors", type:"full_text"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
                 // Searching across fields with one term
-                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "grey", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec(null, "grey", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
             })
             .then(function() {
                 // Searching across fields with multiple terms
-                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "small black", "descending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec(null, "small black", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["lizard", "cat"]);
             })
             .then(function() {
                 // Searching across fields with one term starred
-                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr*", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec(null, "gr*", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
             })
             .then(function() {
                 // Searching across fields with multiple terms one being negated
-                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "black NOT tabby", "descending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec(null, "black NOT tabby", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
             })
             .then(function() {
                 // Searching across fields with multiple terms (one starred, one negated)
-                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr* NOT small", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec(null, "gr* NOT small", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
             })
             .then(function(entries) {
                 // Searching one field with one term
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "grey");
+                var querySpec = self.smartstore.buildMatchQuerySpec("colors", "grey");
                 return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
             })
             .then(function() {
                 // Searching one field with multiple terms
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "white black", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("colors", "white black", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
             })
             .then(function() {
                 // Searching one field with one term starred
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "gr*", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("colors", "gr*", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
             })
             .then(function() {
                 // Searching one field with multiple terms one being negated
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "black NOT tabby", "descending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("colors", "black NOT tabby", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
             })
             .then(function() {
                 // Searching one with multiple terms (one starred, one negated)
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("description", "m* NOT small", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("description", "m* NOT small", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
             })
             .then(function(param) { 
@@ -1176,20 +1164,20 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
     SmartStoreTestSuite.prototype.tryQuery = function(soupName, querySpec, expectedNames) {
         var self = this;
-        return self.querySoup(soupName, querySpec)
+        return self.smartstoreClient.querySoup(soupName, querySpec)
             .then(function(cursor) {
                 var results = cursor.currentPageOrderedEntries;
                 QUnit.equal(results.length, expectedNames.length, "check currentPageOrderedEntries when trying match '" + querySpec.matchKey + "'");
                 for (var i=0; i<results.length; i++) {
                     QUnit.equal(results[i].name,expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "'");
                 }
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) {
                 // Now running query with select paths
                 var querySpecWithSelectPaths= JSON.parse(JSON.stringify(querySpec));
                 querySpecWithSelectPaths.selectPaths = ["name", "name"];
-                return self.querySoup(soupName, querySpecWithSelectPaths);
+                return self.smartstoreClient.querySoup(soupName, querySpecWithSelectPaths);
             })
             .then(function(cursor) {
                 var results = cursor.currentPageOrderedEntries;
@@ -1198,7 +1186,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                     QUnit.equal(results[i][0],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
                     QUnit.equal(results[i][1],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
                 }
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
     };
 
@@ -1217,22 +1205,22 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"full_text"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "grey", "descending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("attributes.color", "grey", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
             })
             .then(function() {
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "white black", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("attributes.color", "white black", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
             })
             .then(function() {
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "gr*", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("attributes.color", "gr*", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
             })
             .then(function() {
-                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "black NOT tabby", "descending", 10, "name");
+                var querySpec = self.smartstore.buildMatchQuerySpec("attributes.color", "black NOT tabby", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
             })
             .then(function(param) { 
@@ -1256,14 +1244,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%grey%", "descending", 10, "name");
+                var querySpec = self.smartstore.buildLikeQuerySpec("attributes.color", "%grey%", "descending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
             })
             .then(function() {
-                var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%gr%", "ascending", 10, "name");
+                var querySpec = self.smartstore.buildLikeQuerySpec("attributes.color", "%gr%", "ascending", 10, "name");
                 return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
             })
             .then(function(param) { 
@@ -1287,10 +1275,10 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.color", "[\"grey\"]");
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.color", "[\"grey\"]");
                 return self.tryQuery(soupName, querySpec, ["elephant"]);
             })
             .then(function(param) { 
@@ -1314,18 +1302,18 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + soupName + ":_soup} FROM {" + soupName + "} where {" + soupName + ":attributes.color} LIKE '%grey%' ORDER BY LOWER({" + soupName + ":name})" , 5);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("SELECT {" + soupName + ":_soup} FROM {" + soupName + "} where {" + soupName + ":attributes.color} LIKE '%grey%' ORDER BY LOWER({" + soupName + ":name})" , 5);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
                 QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
                 QUnit.equal("dog", cursor.currentPageOrderedEntries[0][0].name, "check first row");
                 QUnit.equal("elephant", cursor.currentPageOrderedEntries[1][0].name, "check second row");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1352,14 +1340,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 //pick out a compound path value and ensure that we can query for the same entry
                 var selectedEntry = entries[1];
                 selectedUrl = selectedEntry.attributes.url;
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
-                return self.querySoup(soupName, querySpec); 
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
+                return self.smartstoreClient.querySoup(soupName, querySpec); 
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "currentPageOrderedEntries correct");
                 var foundEntry = cursor.currentPageOrderedEntries[0];
                 QUnit.equal(foundEntry.attributes.url,selectedUrl,"Verify same entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1376,10 +1364,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         
         var querySpec = new QuerySpec(null);
         querySpec.queryType = null; 
-        self.querySoupNoAssertion(self.defaultSoupName, querySpec)
-            .then(function(param) { 
-                self.setAssertionFailed("querySoup should have failed"); 
-            })
+        self.smartstoreClient.querySoup(self.defaultSoupName, querySpec)
             .catch(function(param) { 
                 self.finalizeTest(); 
             });
@@ -1400,17 +1385,17 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"shots", type:"integer"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                var querySpec = navigator.smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
-                return self.querySoup(soupName, querySpec);
+                var querySpec = self.smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
+                return self.smartstoreClient.querySoup(soupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
                 QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
                 QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify last entry");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1428,14 +1413,14 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("select count(*) from {" + self.defaultSoupName + "}", 1);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("select count(*) from {" + self.defaultSoupName + "}", 1);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
                 QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
                 QUnit.equal("[[3]]", JSON.stringify(cursor.currentPageOrderedEntries), "check currentPageOrderedEntries");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1467,59 +1452,59 @@ if (typeof SmartStoreTestSuite === 'undefined') {
 
         var buildQuerySpec = function(comparison) {
             var smartQuery = "select {alphabetSoup:_soup} from {alphabetSoup} where {alphabetSoup:rank} " + comparison + " order by lower({alphabetSoup:Name})";
-            return navigator.smartstore.buildSmartQuerySpec(smartQuery, 5);
+            return self.smartstore.buildSmartQuerySpec(smartQuery, 5);
         };
 
         self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"rank", type:"integer"}])
             .then(function() {
-                return self.upsertSoupEntries(soupName,rawEntries);
+                return self.smartstoreClient.upsertSoupEntries(soupName,rawEntries);
             })
             .then(function(entries) {
-                return self.runSmartQuery(buildQuerySpec("!= 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec("!= 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "ABDE");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                return self.runSmartQuery(buildQuerySpec("= 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec("= 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "C");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                return self.runSmartQuery(buildQuerySpec("< 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec("< 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "AB");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                return self.runSmartQuery(buildQuerySpec("<= 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec("<= 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "ABC");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                return self.runSmartQuery(buildQuerySpec("> 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec("> 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "DE");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
-                return self.runSmartQuery(buildQuerySpec(">= 3"));
+                return self.smartstoreClient.runSmartQuery(buildQuerySpec(">= 3"));
             })
             .then(function(cursor) {
                 QUnit.equal(pluckNames(cursor), "CDE");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1539,8 +1524,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 testEntries = entries;
                 QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%bo%'", 10);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%bo%'", 10);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 var rows = cursor.currentPageOrderedEntries;
@@ -1551,7 +1536,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 // Should return 2nd and 3rd entries.
                 QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
                 QUnit.equal("Robot",  actualNames[1]);
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1571,8 +1556,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 testEntries = entries;
                 QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%o%' ORDER BY LOWER({" + self.defaultSoupName + ":Name})", 10);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%o%' ORDER BY LOWER({" + self.defaultSoupName + ":Name})", 10);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 var rows = cursor.currentPageOrderedEntries;
@@ -1583,7 +1568,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
                 QUnit.equal("Robot",  actualNames[1]);
                 QUnit.equal("Todd Stellanova", actualNames[2]);
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1603,8 +1588,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 testEntries = entries;
                 QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300B')", 10);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300B')", 10);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
@@ -1613,7 +1598,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 // Should return 1st and 2nd entries.
                 QUnit.equal(JSON.stringify([testEntries[0].Name]), JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
                 QUnit.equal(JSON.stringify([testEntries[1].Name]), JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1633,8 +1618,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 testEntries = entries;
                 QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name}, {" + self.defaultSoupName + ":Id} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300C')", 10);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name}, {" + self.defaultSoupName + ":Id} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300C')", 10);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
@@ -1645,7 +1630,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                             JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
                 QUnit.equal(JSON.stringify([testEntries[2].Name, testEntries[2].Id]), 
                             JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1672,8 +1657,8 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
                 expectedEntry = entries[0];
                 var sql = "select {" + self.defaultSoupName + ":_soup}, {" + self.defaultSoupName + ":_soupEntryId}, {" + self.defaultSoupName + ":_soupLastModifiedDate} from {" + self.defaultSoupName + "} where {" + self.defaultSoupName + ":Id} = '" + expectedEntry.Id + "'";
-                var querySpec = navigator.smartstore.buildSmartQuerySpec(sql, 1);
-                return self.runSmartQuery(querySpec);
+                var querySpec = self.smartstore.buildSmartQuerySpec(sql, 1);
+                return self.smartstoreClient.runSmartQuery(querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
@@ -1683,7 +1668,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equal(cursor.currentPageOrderedEntries[0][0].Name, expectedEntry.Name, "check _soup's Name returned");
                 QUnit.equal(cursor.currentPageOrderedEntries[0][1], expectedEntry._soupEntryId, "check _soupEntryId returned");
                 QUnit.equal(cursor.currentPageOrderedEntries[0][2], expectedEntry._soupLastModifiedDate, "check _soupLastModifieddate returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1700,10 +1685,10 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Start clean
-        self.removeSoup(soupName)
+        self.smartstoreClient.removeSoup(soupName)
             .then(function() {
                 // Create soup
-                return self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(soupName, self.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK");
@@ -1724,13 +1709,10 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Check soup does not exist
-        self.soupExists(soupName)
+        self.smartstoreClient.soupExists(soupName)
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should not already exist");
-                return self.getSoupIndexSpecsNoAssertion(soupName);
-            })
-            .then(function() {
-                self.setAssertionFailed("getSoupIndexSpecs with bogus soupName should fail");
+                return self.getSoupIndexSpecs(soupName);
             })
             .catch(function() {            
                 QUnit.ok(true,"getSoupIndexSpecs should fail for bogus soupName");
@@ -1780,7 +1762,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
                 // Alter soup
-                return self.alterSoup(self.defaultSoupName, alteredIndexes, reIndexData);
+                return self.smartstoreClient.alterSoup(self.defaultSoupName, alteredIndexes, reIndexData);
             })
             .then(function() {
                 // Checking altered soup indexes 
@@ -1788,21 +1770,21 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function() {
                 // Query by a new indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function() {
                 // Query by a previously indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1826,7 +1808,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
                 // Alter soup internal -> external
-                return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec1, alteredIndexes1, reIndexData);
+                return self.smartstoreClient.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec1, alteredIndexes1, reIndexData);
             })
             .then(function() {
                 // Checking altered soup indexes 
@@ -1838,26 +1820,26 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function() {
                 // Query by a new indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function() {
                 // Query by a previously indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
                 // Alter soup external -> internal
-                return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec2, alteredIndexes2, reIndexData);
+                return self.smartstoreClient.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec2, alteredIndexes2, reIndexData);
             })
             .then(function() {
                 // Checking altered soup indexes 
@@ -1869,21 +1851,21 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function() {
                 // Query by a new indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("department", "Engineering", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("department", "Engineering", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 2 : 0, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function() {
                 // Query by a previously indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1899,13 +1881,10 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         var self = this;
 
         // Check soup does not exist
-        self.soupExists(soupName)
+        self.smartstoreClient.soupExists(soupName)
             .then(function(exists) {
                 QUnit.equals(exists, false, "soup should not already exist");
-                return self.alterSoupNoAssertion(soupName, [{path:"key", type:"string"}], true);
-            })
-            .then(function() {
-                self.setAssertionFailed("alterSoup with bogus soupName should fail");
+                return self.smartstoreClient.alterSoup(soupName, [{path:"key", type:"string"}], true);
             })
             .catch(function() {            
                 QUnit.ok(true,"alterSoup should fail for bogus soupName");
@@ -1925,7 +1904,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             .then(function(entries) {
                 QUnit.equal(entries.length, 3,"check stuffTestSoup result");
                 // Alter soup
-                return self.alterSoup(self.defaultSoupName, alteredIndexes, false);
+                return self.smartstoreClient.alterSoup(self.defaultSoupName, alteredIndexes, false);
             })
             .then(function() {
                 // Checking altered soup indexes 
@@ -1933,34 +1912,34 @@ if (typeof SmartStoreTestSuite === 'undefined') {
             })
             .then(function() {
                 // Query by a new indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(cursor) {
                 // Re-index soup
-                return self.reIndexSoup(self.defaultSoupName, ["attributes.type"]);
+                return self.smartstoreClient.reIndexSoup(self.defaultSoupName, ["attributes.type"]);
             })
             .then(function() {
                 // Query by a new indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function() {
                 // Query by a previously indexed field
-                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 
@@ -1973,7 +1952,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
      * Helper method checkSoupIndexes
      */
     SmartStoreTestSuite.prototype.checkSoupIndexes = function(soupName, expectedIndexes) {
-        return this.getSoupIndexSpecs(soupName)
+        return this.smartstoreClient.getSoupIndexSpecs(soupName)
             .then(function(soupIndexes) {
                 QUnit.equals(soupIndexes.length, expectedIndexes.length, "Check number of soup indices");
                 for (i = 0; i< expectedIndexes.length; i++) {
@@ -1987,7 +1966,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
      * Helper method checkSoupSpec
      */
     SmartStoreTestSuite.prototype.checkSoupSpec = function(soupName, expectedSoupSpec) {
-        return this.getSoupSpec(soupName)
+        return this.smartstoreClient.getSoupSpec(soupName)
             .then(function(soupSpec) {
                 QUnit.equals(soupSpec.name, expectedSoupSpec.name, "Check soup name in soup spec");
                 QUnit.equals(soupSpec.features.length, expectedSoupSpec.features.length, "Check features in soup spec");
@@ -2009,18 +1988,18 @@ if (typeof SmartStoreTestSuite === 'undefined') {
         self.stuffTestSoup()
             .then(function(entries) {
                 QUnit.equal(entries.length, 3);
-                return self.clearSoup(self.defaultSoupName);
+                return self.smartstoreClient.clearSoup(self.defaultSoupName);
             })
             .then(function(status) {
                 QUnit.equal(status, "OK", "clearSoup OK");
                 
-                var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
-                return self.querySoup(self.defaultSoupName, querySpec);
+                var querySpec = self.smartstore.buildAllQuerySpec("Name");
+                return self.smartstoreClient.querySoup(self.defaultSoupName, querySpec);
             })
             .then(function(cursor) {
                 var nEntries = cursor.currentPageOrderedEntries.length;
                 QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
-                return self.closeCursor(cursor);
+                return self.smartstoreClient.closeCursor(cursor);
             })
             .then(function(param) { 
                 QUnit.ok(true,"closeCursor ok"); 

--- a/test/SFSmartStoreTestSuite.js
+++ b/test/SFSmartStoreTestSuite.js
@@ -31,1995 +31,2002 @@
  */
 if (typeof SmartStoreTestSuite === 'undefined') { 
 
-/**
- * Constructor for SmartStoreTestSuite
- */
-var SmartStoreTestSuite = function () {
-    AbstractSmartStoreTestSuite.call(this, 
-                                     "smartstore", 
-                                     [
-                                         {path:"Name", type:"string"}, 
-                                         {path:"Id", type:"string"}
-                                     ]);
-
-    // To run specific tests
-    // this.testsToRun = ["testSmartQueryWithIntegerCompare"];
-};
-
-// We are sub-classing AbstractSmartStoreTestSuite
-SmartStoreTestSuite.prototype = new AbstractSmartStoreTestSuite();
-SmartStoreTestSuite.prototype.constructor = SmartStoreTestSuite;
-
-
-/**
- * Helper method that adds three soup entries to default soup
- */
-SmartStoreTestSuite.prototype.stuffTestSoup = function() {
-    console.log("In SFSmartStoreTestSuite.stuffTestSoup");
-    var myEntry1 = { Name: "Todd Stellanova", Id: "00300A", attributes:{type:"Contact"}, department:"Engineering"};
-    var myEntry2 = { Name: "Pro Bono Bonobo",  Id: "00300B", attributes:{type:"Contact"}, department:"Biology"};
-    var myEntry3 = { Name: "Robot", Id: "00300C", attributes:{type:"Contact"}, department:"Engineering"};
-    var entries = [myEntry1, myEntry2, myEntry3];
-    return this.addEntriesToTestSoup(entries);
-};
-
-
-/** 
- * TEST getDatabaseSize
- */
-SmartStoreTestSuite.prototype.testGetDatabaseSize  = function() {
-    console.log("In SFSmartStoreTestSuite.testGetDatabaseSize");
-    var self = this;
-    var initialSize;
-
-    // Start clean
-    self.getDatabaseSize()
-        .pipe(function(size) {
-            QUnit.ok(size > 0,"check getDatabaseSize result: " + size);
-            initialSize = size;
-            return self.addGeneratedEntriesToTestSoup(2000)
-        })
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 2000, "check addGeneratedEntriesToTestSoup result");
-            return self.getDatabaseSize();
-        })
-        .pipe(function(size) {
-            QUnit.ok(size > initialSize,"check getDatabaseSize result: " + size);
-            self.finalizeTest();
-        });
-};
-
-/** 
- * TEST global store vs regular store with registerSoup / soupExists / removeSoup
- */
-SmartStoreTestSuite.prototype.testRegisterRemoveSoupGlobalStore = function()  {
-    console.log("In SFSmartStoreTestSuite.testRegisterRemoveSoupGlobalStore");
-    var soupName = "soupForTestRegisterRemoveSoupGlobalStore";
-
-    var self = this;
-    var GLOBAL_STORE = true;
-    var REGULAR_STORE = false;
-
-    // Start clean
-    $.when(self.removeSoup(REGULAR_STORE, soupName),
-           self.removeSoup(GLOBAL_STORE, soupName))
-        .pipe(function() {
-            // Check soup does not exist in either stores
-            return $.when(self.soupExists(REGULAR_STORE, soupName),
-                          self.soupExists(GLOBAL_STORE, soupName));
-        })
-        .pipe(function(exists, existsGlobal) {
-            QUnit.equals(exists, false, "soup should not already exist in regular store");
-            QUnit.equals(existsGlobal, false, "soup should not already exist in global store");
-            // Create soup in global store
-            return self.registerSoup(GLOBAL_STORE, soupName, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName2) {
-            QUnit.equals(soupName2,soupName,"registered soup OK in global store");
-            // Check soup exist only in global store
-            return $.when(self.soupExists(REGULAR_STORE, soupName),
-                          self.soupExists(GLOBAL_STORE, soupName));
-        })
-        .pipe(function(exists, existsGlobal) {
-            QUnit.equals(exists, false, "soup should not exist in regular store");
-            QUnit.equals(existsGlobal, true, "soup should now exist in global store");
-            // Create soup in regular store
-            return self.registerSoup(REGULAR_STORE, soupName, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName2) {
-            QUnit.equals(soupName2,soupName,"registered soup OK in regular store");
-            // Check soup exist only in both stores
-            return $.when(self.soupExists(REGULAR_STORE, soupName),
-                          self.soupExists(GLOBAL_STORE, soupName));
-        })
-        .pipe(function(exists, existsGlobal) {
-            QUnit.equals(exists, true, "soup should now exist in regular store");
-            QUnit.equals(existsGlobal, true, "soup should exist in global store");
-            // Remove soup from global store
-            return self.removeSoup(GLOBAL_STORE, soupName);
-        })
-        .pipe(function() {
-            // Check soup exist only in regular store
-            return $.when(self.soupExists(REGULAR_STORE, soupName),
-                          self.soupExists(GLOBAL_STORE, soupName));
-        })
-        .pipe(function(exists, existsGlobal) {
-            QUnit.equals(exists, true, "soup should still exist in regular store");
-            QUnit.equals(existsGlobal, false, "soup should no longer exist in global store");
-            // Remove soup from regular store
-            return self.removeSoup(REGULAR_STORE, soupName);
-        })
-        .pipe(function() {
-            // Check soup no longer exist in either store
-            return $.when(self.soupExists(REGULAR_STORE, soupName),
-                          self.soupExists(GLOBAL_STORE, soupName));
-        })
-        .done(function(exists, existsGlobal) {
-            QUnit.equals(exists, false, "soup should no longer exist in regular store");
-            QUnit.equals(existsGlobal, false, "soup should no longer exist in global store");
-            self.finalizeTest();
-        });
-};
-    
-/** 
- * TEST registerSoup / soupExists / removeSoup 
- */
-SmartStoreTestSuite.prototype.testRegisterRemoveSoup = function()  {
-    console.log("In SFSmartStoreTestSuite.testRegisterRemoveSoup");
-    var soupName = "soupForTestRegisterRemoveSoup";
-
-    var self = this;
-
-    // Start clean
-    self.removeSoup(soupName)
-        .pipe(function() {
-            // Check soup does not exist
-            return self.soupExists(soupName);
-        })
-        .pipe(function(exists) {
-            QUnit.equals(exists, false, "soup should not already exist");
-            // Create soup
-            return self.registerSoup(soupName, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName2) {
-            QUnit.equals(soupName2,soupName,"registered soup OK");
-            // Check soup now exists
-            return self.soupExists(soupName);
-        }, function(err) {QUnit.ok(false,"self.registerSoup failed " + err);})
-        .pipe(function(exists) {
-            QUnit.equals(exists, true, "soup should now exist");
-            // Attempt to register the same soup again
-            return self.registerSoup(soupName, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName3) {
-            QUnit.equals(soupName3,soupName,"re-registered existing soup OK");
-            // Remove soup
-            return self.removeSoup(soupName);
-        }, function(err) {QUnit.ok(false,"re-registering existing soup failed " + err);})
-        .pipe(function() {
-            // Check soup no longer exists
-            return self.soupExists(soupName);
-        })
-        .done(function(exists) {
-            QUnit.equals(exists, false, "soup should no longer exist");
-            self.finalizeTest();
-        });
-}; 
-
-/** 
- * TEST registerSoupWithSpec / getSoupSpec / removeSoup 
- */
-SmartStoreTestSuite.prototype.testRegisterWithSpec = function()  {
-    console.log("In SFSmartStoreTestSuite.testRegisterWithSpec");
-    var soupName = "soupForTestRegisterWithSpec";
-
-    var self = this;
-
-    // Start clean
-    self.removeSoup(soupName)
-        .pipe(function() {
-            // Check soup does not exist
-            return self.soupExists(soupName);
-        })
-        .pipe(function(exists) {
-            QUnit.equals(exists, false, "soup should not already exist");
-            // Create soup
-            return self.registerSoupWithSpec({name:soupName, features:["externalStorage"]}, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName2) {
-            QUnit.equals(soupName2,soupName,"registered soup OK");
-            // Check soup now exists
-            return self.soupExists(soupName);
-        }, function(err) {QUnit.ok(false,"self.registerSoupWithSpec failed " + err);})
-        .pipe(function(exists) {
-            QUnit.equals(exists, true, "soup should now exist");
-            // Check soup spec
-            return self.checkSoupSpec(soupName, {name:soupName, features:["externalStorage"]});
-        })
-        .pipe(function() {
-            // Remove soup
-            return self.removeSoup(soupName);
-        }, function(err) {QUnit.ok(false,"self.getSoupSpec failed " + err);})
-        .pipe(function() {
-            // Check soup no longer exists
-            return self.soupExists(soupName);
-        })
-        .done(function(exists) {
-            QUnit.equals(exists, false, "soup should no longer exist");
-            self.finalizeTest();
-        });
-}; 
-
-
-/** 
- * TEST registerSoup with bogus soup
- */
-SmartStoreTestSuite.prototype.testRegisterBogusSoup = function()  {
-    console.log("In SFSmartStoreTestSuite.testRegisterBogusSoup");
-    var soupName = null;//intentional bogus soupName
-    var self = this;
-
-    self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes)
-        .done(function(soupName2) {
-            self.setAssertionFailed("registerSoup should fail with bogus soupName " + soupName2);
-        })
-        .fail(function() {            
-            QUnit.ok(true,"registerSoup should fail with bogus soupName");
-            self.finalizeTest();
-        });
-};
-
-
-/** 
- * TEST registerSoup with no indices
- */
-SmartStoreTestSuite.prototype.testRegisterSoupNoIndices = function()  {
-    console.log("In SFSmartStoreTestSuite.testRegisterSoupNoIndices");
-
-    var soupName = "soupForRegisterNoIndices";
-    var self = this;
-
-    // Start clean
-    self.removeSoup(soupName)
-        .pipe(function() {
-            // Check soup does not exist
-            return self.soupExists(soupName);
-        })
-        .pipe(function(exists) {
-            QUnit.equals(exists, false, "soup should not already exist");
-            // Create soup
-            return self.registerSoupNoAssertion(soupName, []);
-        })
-        .done(function(soupName2) {
-            self.setAssertionFailed("registerSoup should fail with bogus indices " + soupName2);
-        })
-        .fail(function() {            
-            QUnit.ok(true,"registerSoup should fail with bogus indices");
-            self.finalizeTest();
-        });
-}
-
-/** 
- * TEST upsertSoupEntries 
- */
-SmartStoreTestSuite.prototype.testUpsertSoupEntries = function()  {
-    console.log("In SFSmartStoreTestSuite.testUpsertSoupEntries");
-
-    var self = this;
-    self.addGeneratedEntriesToTestSoup(7)
-        .pipe(function(entries1) {
-            QUnit.equal(entries1.length, 7);
-            
-            //upsert another batch
-            return self.addGeneratedEntriesToTestSoup(12);
-        })
-        .pipe(function(entries2) {
-            QUnit.equal(entries2.length, 12);
-            //modify the initial entries
-            for (var i = 0; i < entries2.length; i++) {
-                var e = entries2[i];
-                e.updatedField = "Mister Toast " + i;
-            }
-            
-            //update the entries
-            return self.addEntriesToTestSoup(entries2);
-        })
-        .done(function(entries3) {
-            QUnit.equal(entries3.length,12,"updated list match initial list len");
-            QUnit.equal(entries3[0].updatedField,"Mister Toast 0","updatedField is correct");
-            self.finalizeTest();
-        });
-}; 
-
-/** 
- * TEST upsertSoupEntriesWithExternalId
- */
-SmartStoreTestSuite.prototype.testUpsertSoupEntriesWithExternalId = function()  {
-    console.log("In SFSmartStoreTestSuite.testUpsertSoupEntriesWithExternalId");
-
-    var self = this;
-    self.addGeneratedEntriesToTestSoup(11)
-        .pipe(function(entries1) {
-            QUnit.equal(entries1.length, 11);
-            
-            // Now upsert an overlapping batch, using an external ID path.
-            var entries2 = self.createGeneratedEntries(16);
-            for (var i = 0; i < entries2.length; i++) {
-                var entry = entries2[i];
-                entry.updatedField = "Mister Toast " + i;
-            }
-            var externalIdPath = self.defaultSoupIndexes[0].path;
-            return self.upsertEntriesToSoupWithExternalIdPath(self.defaultSoupName, entries2, externalIdPath);
-        })
-        .pipe(function(entries3) {
-            QUnit.equal(entries3.length, 16);
-            
-            // Now, query the soup for all entries, and make sure that we have only 16.
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name", null, 25);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 16, "Are totalEntries correct?");
-            QUnit.equal(cursor.totalPages, 1, "Are totalPages correct?");
-            var orderedEntries = cursor.currentPageOrderedEntries;
-            var nEntries = orderedEntries.length;
-            QUnit.equal(nEntries, 16, "Are there 16 entries in total?");
-            QUnit.equal(orderedEntries[0]._soupEntryId, 1, "Is the first soup entry ID correct?");
-            QUnit.equal(orderedEntries[0].updatedField, "Mister Toast 0", "Is the first updated field correct?");
-            QUnit.equal(orderedEntries[15]._soupEntryId, 16, "Is the last soup entry ID correct?");
-            QUnit.equal(orderedEntries[15].updatedField, "Mister Toast 15", "Is the last updated field correct?");
-            
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-}; 
-
-
-/** 
- * TEST upsertSoupEntries to non existent soup
- */
-SmartStoreTestSuite.prototype.testUpsertToNonexistentSoup = function()  {
-    console.log("In SFSmartStoreTestSuite.testUpsertToNonexistentSoup");
-
-    var self = this;
-    var entries = [{a:1},{a:2},{a:3}];
-    
-    self.upsertSoupEntriesNoAssertion("nonexistentSoup", entries)
-        .done(function(upsertedEntries) {
-            self.setAssertionFailed("upsertSoupEntries should fail with nonexistent soup ");
-        })
-        .fail(function() {            
-            QUnit.ok(true,"upsertSoupEntries should fail with nonexistent soup");
-            self.finalizeTest();
-        });
-};
-    
-/**
- * TEST retrieveSoupEntries 
- */
-SmartStoreTestSuite.prototype.testRetrieveSoupEntries = function()  {
-    console.log("In SFSmartStoreTestSuite.testRetrieveSoupEntries");
-    
-    var self = this; 
-    var soupEntry0Id;
-    var soupEntry2Id;
-
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            soupEntry0Id = entries[0]._soupEntryId;
-            soupEntry2Id = entries[2]._soupEntryId;
-            
-            return self.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id]);
-        })
-        .done(function(retrievedEntries) {
-            QUnit.equal(retrievedEntries.length, 2);
-            
-            var entryIdArray = new Array();
-            for (var i = 0; i < retrievedEntries.length; i++) {
-                entryIdArray[i] = retrievedEntries[i]._soupEntryId;
-            }
-            self.collectionContains(entryIdArray, soupEntry0Id);
-            self.collectionContains(entryIdArray, soupEntry2Id);
-            self.finalizeTest();
-        }); 
-};
-
-
-/**
- * TEST removeFromSoup by ids
- */
-SmartStoreTestSuite.prototype.testRemoveFromSoup = function()  {
-    console.log("In SFSmartStoreTestSuite.testRemoveFromSoup");    
-    
-    var self = this; 
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            var soupEntryIds = [];
-            QUnit.equal(entries.length, 3);
-            
-            for (var i = entries.length - 1; i >= 0; i--) {
-                var entry = entries[i];
-                soupEntryIds.push(entry._soupEntryId);
-            }
-            
-            return self.removeFromSoup(self.defaultSoupName, soupEntryIds);
-        })
-        .pipe(function(status) {
-            QUnit.equal(status, "OK", "removeFromSoup OK");
-            
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST removeFromSoup by query
- */
-SmartStoreTestSuite.prototype.testRemoveFromSoupByQuery = function()  {
-    console.log("In SFSmartStoreTestSuite.testRemoveFromSoupByQuery");    
-    
-    var self = this; 
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            var querySpecForRemove = navigator.smartstore.buildExactQuerySpec("Name", "Robot");
-            return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
-        })
-        .pipe(function(status) {
-            QUnit.equal(status, "OK", "removeFromSoup OK");
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify second entry");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            var querySpecForRemove = navigator.smartstore.buildLikeQuerySpec("Name", "%Stella%");
-            return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
-        })
-        .pipe(function(status) {
-            QUnit.equal(status, "OK", "removeFromSoup OK");
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify only entry");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            var querySpecForRemove = navigator.smartstore.buildAllQuerySpec("Name");
-            return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
-        })
-        .pipe(function(status) {
-            QUnit.equal(status, "OK", "removeFromSoup OK");
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Id");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check currentPageOrderedEntries");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST querySoup with exact query
- */
-SmartStoreTestSuite.prototype.testQuerySoupWithExactQuery = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupWithExactQuery"); 
-    
-    var self = this;
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 1, "wrong number of results");
-            QUnit.equal(cursor.currentPageOrderedEntries[0]["Name"], "Robot", "wrong name");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            // Now querying with select paths
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot",null,null,null,["Name", "Id"]);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 1, "wrong number of results");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0], "Robot", "wrong name");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][1], "00300C", "wrong id");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-
-/**
- * TEST querySoup with all query with descending sort order
- */
-SmartStoreTestSuite.prototype.testQuerySoupWithAllQueryDescending = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupWithAllQueryDescending");   
-    
-    var self = this;
-    self.stuffTestSoup().
-        pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending");       
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify second entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[2].Name,"Pro Bono Bonobo","verify third entry");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            // Now querying with select paths
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending", null, ["Name", "Id"]);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Todd Stellanova","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1][0],"Robot","verify second entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[2][0],"Pro Bono Bonobo","verify third entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300A","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300C","verify second entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[2][1],"00300B","verify third entry");
-
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST querySoup with range query using order path
- */
-SmartStoreTestSuite.prototype.testQuerySoupWithRangeQueryWithOrderPath = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupWithRangeQueryWithOrderPath");   
-    
-    var self = this;
-    self.stuffTestSoup().
-        pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name");
-            // should match 00300A and 00300B but sort by name
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Id,"00300B","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Todd Stellanova","verify last entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1].Id,"00300A","verify last entry");
-
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            // Now querying with select paths
-            var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name", ["Name", "Id"]);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Pro Bono Bonobo","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1][0],"Todd Stellanova","verify second entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300B","verify first entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300A","verify second entry");
-
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST querySoup with bad query spec
- */
-SmartStoreTestSuite.prototype.testQuerySoupBadQuerySpec = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupBadQuerySpec"); 
-    
-    var self = this;
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            
-            //query on a nonexistent index
-            var querySpec = navigator.smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");             
-            
-            return self.querySoupNoAssertion(self.defaultSoupName, querySpec);
-        })
-        .done(function(cursor) {
-            self.setAssertionFailed("querySoup with bogus querySpec should fail");
-        })
-        .fail(function(param) { 
-            QUnit.ok(true,"querySoup with bogus querySpec should fail");
-            self.finalizeTest();                
-        });
-};
-
-
-/**
- * TEST querySoup  with an endKey and no beginKey
- */
-SmartStoreTestSuite.prototype.testQuerySoupEndKeyNoBeginKey = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupEndKeyNoBeginKey"); 
-    var self = this;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            //keep in sync with stuffTestSoup
-            var querySpec = navigator.smartstore.buildRangeQuerySpec("Name",null,"Robot");              
-
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 2, "nEntries matches endKey");
-            QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify last entry");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST querySoup  with beginKey and no endKey
- */
-SmartStoreTestSuite.prototype.testQuerySoupBeginKeyNoEndKey = function()  {
-    console.log("In SFSmartStoreTestSuite.testQuerySoupBeginKeyNoEndKey"); 
-    var self = this;
-
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            //keep in sync with stuffTestSoup
-            var querySpec = navigator.smartstore.buildRangeQuerySpec("Name","Robot",null);              
-
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 2, "nEntries matches beginKey");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Robot","verify first entry");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST testManipulateCursor
- */
-SmartStoreTestSuite.prototype.testManipulateCursor = function()  {
-  console.log("In SFSmartStoreTestSuite.testManipulateCursor");  
-  var self = this;
-
-  var NUM_ENTRIES = 42;
-  var PAGE_SIZE = 20;
-  var LAST_PAGE_SIZE = NUM_ENTRIES % PAGE_SIZE; // 2
-  var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 3
-  
-  var checkPage = function(cursor, expectedPage) {
-      var expectedPageSize = (expectedPage < NUM_PAGES - 1 ? PAGE_SIZE : LAST_PAGE_SIZE);
-      var expectedIdOfFirstRowOnPage = "003" + self.padNumber(expectedPage*PAGE_SIZE, NUM_ENTRIES, "0");
-      var expectedIdOfLastRowOnPage = "003" + self.padNumber(expectedPage*PAGE_SIZE+expectedPageSize-1, NUM_ENTRIES, "0");
-
-      QUnit.equal(cursor.currentPageIndex, expectedPage, "currentPageIndex correct");
-      QUnit.equal(cursor.totalEntries, NUM_ENTRIES, "totalEntries correct");
-      QUnit.equal(cursor.totalPages, NUM_PAGES, "totalPages correct");
-      QUnit.equal(cursor.currentPageOrderedEntries.length, expectedPageSize, "pageSize correct");      
-      QUnit.equal(cursor.currentPageOrderedEntries[0].Id, expectedIdOfFirstRowOnPage , "pageSize correct");      
-      QUnit.equal(cursor.currentPageOrderedEntries[expectedPageSize-1].Id, expectedIdOfLastRowOnPage, "pageSize correct");      
-  };
-
-  self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, NUM_ENTRIES);
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            checkPage(cursor, 0);
-            return self.moveCursorToNextPage(cursor);
-        })
-        .pipe(function(cursor) {
-            checkPage(cursor, 1);
-            return self.moveCursorToNextPage(cursor);
-        })
-        .pipe(function(cursor) {
-            checkPage(cursor, 2);
-            return self.moveCursorToPreviousPage(cursor);
-        })
-        .pipe(function(cursor) {
-            checkPage(cursor, 1);
-            return self.moveCursorToNextPage(cursor);
-        })
-        .pipe(function(cursor) {
-            checkPage(cursor, 2);
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST testMoveCursorToPreviousPageFromFirstPage
- */
-SmartStoreTestSuite.prototype.testMoveCursorToPreviousPageFromFirstPage = function()  {
-  console.log("In SFSmartStoreTestSuite.testMoveCursorToPreviousPageFromFirstPage");  
-  var self = this;
-
-  var NUM_ENTRIES = 8;
-  var PAGE_SIZE = 5;
-  var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 2
-  
-  self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, NUM_ENTRIES);
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-            return self.moveCursorToPreviousPageNoAssertion(cursor);
-        })
-        .fail(function(cursor, error) {
-            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex should not have changed");
-            QUnit.ok(error.message.indexOf("moveCursorToPreviousPage") == 0, "error should be about moveCursorToPreviousPage");
-            self.closeCursor(cursor)
-                .done(function(param) { 
-                    QUnit.ok(true,"closeCursor ok"); 
-                    self.finalizeTest(); 
-                });
-        });
-};
-
-
-/**
- * TEST testMoveCursorToNextPageFromLastPage
- */
-SmartStoreTestSuite.prototype.testMoveCursorToNextPageFromLastPage = function()  {
-  console.log("In SFSmartStoreTestSuite.testMoveCursorToNextPageFromLastPage");  
-  var self = this;
-
-  var NUM_ENTRIES = 8;
-  var PAGE_SIZE = 5;
-  var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 2
-  
-  self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, NUM_ENTRIES);
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
-            return self.moveCursorToNextPage(cursor);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex correct");
-            return self.moveCursorToNextPageNoAssertion(cursor);
-        })
-        .fail(function(cursor, error) {
-            QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex should not have changed");
-            QUnit.ok(error.message.indexOf("moveCursorToNextPage") == 0, "error should be about moveCursorToNextPage");
-            self.closeCursor(cursor)
-                .done(function(param) { 
-                    QUnit.ok(true,"closeCursor ok"); 
-                    self.finalizeTest(); 
-                });
-        });
-};
-
-
-/**
- * TEST unusual soup names
- */
-SmartStoreTestSuite.prototype.testArbitrarySoupNames = function() {
-    console.log("In SFSmartStoreTestSuite.testArbitrarySoupNames");    
-    var self = this;
-    var soupName = "123This should-be a_valid.soup+name!?100";
-    
-    //simply register and verify that the soup exists
-    self.removeAndRecreateSoup(soupName,self.defaultSoupIndexes).
-        done(function() {
-            self.finalizeTest();
-        });
-};
-
-
-/**
- * TEST querySpec factory functions
- */
-SmartStoreTestSuite.prototype.testQuerySpecFactories = function() {
-    console.log("In SFSmartStoreTestSuite.testQuerySpecFactories");
-    var self = this;
-    
-    var path = "Name";
-    var matchKey = "matchKeyValue";
-    var beginKey = "beginKeyValue";
-    var endKey = "endKeyValue";
-    var order = "descending";
-    var pageSize = 17;
-    var orderPath = "orderPathValue";
-    var selectPaths = ["x","y"];
-
-    // Exact query with all args
-    var query =  navigator.smartstore.buildExactQuerySpec(path,matchKey,pageSize,order,orderPath,selectPaths);
-    QUnit.equal(query.queryType,"exact","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.matchKey,matchKey,"check matchKey");
-    QUnit.equal(query.order,order, "check order");
-    QUnit.equal(query.pageSize,pageSize,"check pageSize");
-    QUnit.equal(query.orderPath,orderPath,"check orderPath");
-    QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
-
-    // Exact query with min args
-    query = navigator.smartstore.buildExactQuerySpec(path,matchKey);
-    QUnit.equal(query.queryType,"exact","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.matchKey,matchKey,"check matchKey");
-    QUnit.equal(query.pageSize,10,"check pageSize");
-    QUnit.equal(query.order,"ascending", "check order");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.ok(query.selectPaths == null,"check selectPaths");    
-    
-    // Range query with all args
-    query = navigator.smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize,orderPath,selectPaths);
-    QUnit.equal(query.queryType,"range","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.beginKey,beginKey,"check beginKey");
-    QUnit.equal(query.endKey,endKey,"check endKey");
-    QUnit.equal(query.order,order,"check order");
-    QUnit.equal(query.pageSize,pageSize,"check pageSize");
-    QUnit.equal(query.orderPath,orderPath,"check orderPath");
-    QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
-
-    // Range query with min args
-    query = navigator.smartstore.buildRangeQuerySpec(path,beginKey);
-    QUnit.equal(query.queryType,"range","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.beginKey,beginKey,"check beginKey");
-    QUnit.ok(query.endKey == null,"check endKey");
-    QUnit.equal(query.order,"ascending", "check order");
-    QUnit.equal(query.pageSize,10,"check pageSize");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.ok(query.selectPaths == null,"check selectPaths");    
-    
-    // Like query with all args
-    query = navigator.smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize,orderPath,selectPaths);
-    QUnit.equal(query.queryType,"like","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.likeKey,beginKey,"check likeKey");
-    QUnit.equal(query.order,order,"check order");
-    QUnit.equal(query.pageSize,pageSize,"check pageSize");
-    QUnit.equal(query.orderPath,orderPath,"check orderPath");
-    QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
-    
-    // Like query with min args
-    query = navigator.smartstore.buildLikeQuerySpec(path,beginKey);
-    QUnit.equal(query.queryType,"like","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.likeKey,beginKey,"check likeKey");
-    QUnit.equal(query.order,"ascending", "check order");
-    QUnit.equal(query.pageSize,10,"check pageSize");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.ok(query.selectPaths == null,"check selectPaths");    
-    
-    // All query with all args
-    query = navigator.smartstore.buildAllQuerySpec(path,order,pageSize,selectPaths);
-    QUnit.equal(query.queryType,"range","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.equal(query.order,order,"check order");
-    QUnit.equal(query.pageSize,pageSize,"check pageSize");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
-
-    // All query with min args
-    query = navigator.smartstore.buildAllQuerySpec(path);
-    QUnit.equal(query.queryType,"range","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.equal(query.order,"ascending", "check order");
-    QUnit.equal(query.pageSize,10,"check pageSize");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.ok(query.selectPaths == null,"check selectPaths");    
-
-    // Match query with all args
-    query = navigator.smartstore.buildMatchQuerySpec(path, matchKey, order, pageSize, orderPath, selectPaths);
-    QUnit.equal(query.queryType,"match","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.matchKey,matchKey,"check matchKey");
-    QUnit.equal(query.order,order,"check order");
-    QUnit.equal(query.pageSize,pageSize,"check pageSize");
-    QUnit.equal(query.orderPath,orderPath,"check orderPath");
-    QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
-    
-    // Match query with min args
-    query = navigator.smartstore.buildMatchQuerySpec(path, matchKey);
-    QUnit.equal(query.queryType,"match","check queryType");
-    QUnit.equal(query.indexPath,path,"check indexPath");
-    QUnit.equal(query.matchKey,matchKey,"check matchKey");
-    QUnit.equal(query.order,"ascending", "check order");
-    QUnit.equal(query.pageSize,10,"check pageSize");
-    QUnit.equal(query.orderPath,path,"check orderPath");
-    QUnit.ok(query.selectPaths == null,"check selectPaths");    
-    
-    self.finalizeTest();
-};
-
-/**
- * TEST like query starts with
- */
-SmartStoreTestSuite.prototype.testLikeQuerySpecStartsWith  = function() {
-    console.log("In SFSmartStoreTestSuite.testLikeQuerySpecStartsWith");
-    var self = this;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            // Now querying with select paths
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%", null, null, null, ["Name", "Id"]);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
-            QUnit.equal(cursor.totalPages, 1, "totalPages correct");
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check currentPageOrderedEntries");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Todd Stellanova","verify second entry");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300A","verify second entry");
-
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-
-/**
- * TEST like query ends with
- */
-SmartStoreTestSuite.prototype.testLikeQuerySpecEndsWith  = function() {
-    console.log("In SFSmartStoreTestSuite.testLikeQuerySpecEndsWith");
-    var self = this;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%Stellanova");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST like query inner text
- */
-SmartStoreTestSuite.prototype.testLikeQueryInnerText  = function() {
-    console.log("In SFSmartStoreTestSuite.testLikeQueryInnerText");
-    var self = this;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%ono%");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
-            QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify entry");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST full-text search
- */
-SmartStoreTestSuite.prototype.testFullTextSearch  = function() {
-    console.log("In SFSmartStoreTestSuite.testFullTextSearch");
-    var self = this;
-    var myEntry1 = { name: "elephant", description:"large mammals", colors:"grey"};
-    var myEntry2 = { name: "cat", description:"small mammals", colors:"black tabby white"};
-    var myEntry3 = { name: "dog", description:"medium mammals", colors:"grey black"};
-    var myEntry4 = { name: "lizard", description:"small reptilian", colors:"black green white"};
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
-    var soupName = "animals";
-
-    self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"description", type:"full_text"}, {path:"colors", type:"full_text"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            // Searching across fields with one term
-            var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "grey", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
-        })
-        .pipe(function() {
-            // Searching across fields with multiple terms
-            var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "small black", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["lizard", "cat"]);
-        })
-        .pipe(function() {
-            // Searching across fields with one term starred
-            var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr*", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
-        })
-        .pipe(function() {
-            // Searching across fields with multiple terms one being negated
-            var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "black NOT tabby", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
-        })
-        .pipe(function() {
-            // Searching across fields with multiple terms (one starred, one negated)
-            var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr* NOT small", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
-        })
-        .pipe(function(entries) {
-            // Searching one field with one term
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "grey");
-            return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
-        })
-        .pipe(function() {
-            // Searching one field with multiple terms
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "white black", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
-        })
-        .pipe(function() {
-            // Searching one field with one term starred
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "gr*", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
-        })
-        .pipe(function() {
-            // Searching one field with multiple terms one being negated
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "black NOT tabby", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
-        })
-        .pipe(function() {
-            // Searching one with multiple terms (one starred, one negated)
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("description", "m* NOT small", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-SmartStoreTestSuite.prototype.tryQuery = function(soupName, querySpec, expectedNames) {
-    var self = this;
-    return self.querySoup(soupName, querySpec)
-        .pipe(function(cursor) {
-            var results = cursor.currentPageOrderedEntries;
-            QUnit.equal(results.length, expectedNames.length, "check currentPageOrderedEntries when trying match '" + querySpec.matchKey + "'");
-            for (var i=0; i<results.length; i++) {
-                QUnit.equal(results[i].name,expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "'");
-            }
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) {
-            // Now running query with select paths
-            var querySpecWithSelectPaths= JSON.parse(JSON.stringify(querySpec));
-            querySpecWithSelectPaths.selectPaths = ["name", "name"];
-            return self.querySoup(soupName, querySpecWithSelectPaths);
-        })
-        .pipe(function(cursor) {
-            var results = cursor.currentPageOrderedEntries;
-            QUnit.equal(results.length, expectedNames.length, "check currentPageOrderedEntries when trying match '" + querySpec.matchKey + "' with select paths param");
-            for (var i=0; i<results.length; i++) {
-                QUnit.equal(results[i][0],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
-                QUnit.equal(results[i][1],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
-            }
-            return self.closeCursor(cursor);
-        })
-};
-
-/**
- * TEST full-text search against array node
- */
-SmartStoreTestSuite.prototype.testFullTextSearchAgainstArrayNode  = function() {
-    console.log("In SFSmartStoreTestSuite.testFullTextSearchAgainstArrayNode");
-    var self = this;
-    var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
-    var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
-    var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
-    var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
-    var soupName = "fullTextSearchAgainstArrayNodeSoup";
-
-    self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"full_text"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "grey", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
-        })
-        .pipe(function() {
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "white black", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
-        })
-        .pipe(function() {
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "gr*", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
-        })
-        .pipe(function() {
-            var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "black NOT tabby", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST like query against array node
- */
-SmartStoreTestSuite.prototype.testLikeQueryAgainstArrayNode  = function() {
-    console.log("In SFSmartStoreTestSuite.testLikeQueryAgainstArrayNode");
-    var self = this;
-    var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
-    var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
-    var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
-    var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
-    var soupName = "likeQueryAgainstArrayNodeSoup";
-
-    self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%grey%", "descending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
-        })
-        .pipe(function() {
-            var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%gr%", "ascending", 10, "name");
-            return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST exact query against array node
- */
-SmartStoreTestSuite.prototype.testExactQueryAgainstArrayNode  = function() {
-    console.log("In SFSmartStoreTestSuite.testExactQueryAgainstArrayNode");
-    var self = this;
-    var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
-    var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
-    var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
-    var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
-    var soupName = "exactQueryAgainstArrayNodeSoup";
-
-    self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.color", "[\"grey\"]");
-            return self.tryQuery(soupName, querySpec, ["elephant"]);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST smart query against array node
- */
-SmartStoreTestSuite.prototype.testSmartQueryAgainstArrayNode  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryAgainstArrayNode");
-    var self = this;
-    var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
-    var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
-    var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
-    var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
-    var soupName = "smartQueryAgainstArrayNodeSoup";
-
-    self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + soupName + ":_soup} FROM {" + soupName + "} where {" + soupName + ":attributes.color} LIKE '%grey%' ORDER BY LOWER({" + soupName + ":name})" , 5);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
-            QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
-            QUnit.equal("dog", cursor.currentPageOrderedEntries[0][0].name, "check first row");
-            QUnit.equal("elephant", cursor.currentPageOrderedEntries[1][0].name, "check second row");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-    
-/**
- * TEST query with compound path
- */
-SmartStoreTestSuite.prototype.testCompoundQueryPath  = function() {
-    console.log("In SFSmartStoreTestSuite.testCompoundQueryPath");
-    var self = this;
-    //attributes.url is a nonsensical path but it works for testing compound paths
-    var indices = [{path:"Name", type:"string"}, {path:"Id", type:"string"}, {path:"attributes.url", type:"string"}];
-    var soupName = "compoundPathSoup";
-    var selectedUrl;
-    self.removeAndRecreateSoup(soupName,indices)
-        .pipe(function() {
-            return self.addGeneratedEntriesToSoup(soupName, 3);
-        })
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check addGeneratedEntriesToSoup result");
-            //pick out a compound path value and ensure that we can query for the same entry
-            var selectedEntry = entries[1];
-            selectedUrl = selectedEntry.attributes.url;
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
-            return self.querySoup(soupName, querySpec); 
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "currentPageOrderedEntries correct");
-            var foundEntry = cursor.currentPageOrderedEntries[0];
-            QUnit.equal(foundEntry.attributes.url,selectedUrl,"Verify same entry");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest(); 
-        });
-};
-
-/**
- * TEST query with empty query spec
- */
-SmartStoreTestSuite.prototype.testEmptyQuerySpec  = function() {
-    console.log("In SFSmartStoreTestSuite.testEmptyQuerySpec");
-    var self = this;
-    
-    var querySpec = new QuerySpec(null);
-    querySpec.queryType = null; 
-    self.querySoupNoAssertion(self.defaultSoupName, querySpec)
-    .done(function(param) { 
-        self.setAssertionFailed("querySoup should have failed"); 
-    })
-    .fail(function(param) { 
-        self.finalizeTest(); 
-    });
-};
-
-
-/**
- * TEST query against integer field
- */
-SmartStoreTestSuite.prototype.testIntegerQuerySpec  = function() {
-    console.log("In SFSmartStoreTestSuite.testIntegerQuerySpec");
-    var self = this;
-    var myEntry1 = { Name: "Todd Stellanova", shots:37 };
-    var myEntry2 = { Name: "Pro Bono Bonobo",  shots:92  };
-    var myEntry3 = { Name: "Robot",  shots:0  };
-    var rawEntries = [myEntry1, myEntry2, myEntry3];
-    var soupName = "charmingSoup";
-
-    self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"shots", type:"integer"}])
-    .pipe(function() {
-        return self.upsertSoupEntries(soupName,rawEntries);
-    })
-    .pipe(function(entries) {
-        var querySpec = navigator.smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
-        return self.querySoup(soupName, querySpec);
-    })
-    .pipe(function(cursor) {
-        QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
-        QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
-        QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify last entry");
-        return self.closeCursor(cursor);
-    })
-    .done(function(param) { 
-        QUnit.ok(true,"closeCursor ok"); 
-        self.finalizeTest();
-    });
-};
-
-/**
- * TEST smart query with count
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithCount  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
-    var self = this;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("select count(*) from {" + self.defaultSoupName + "}", 1);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
-            QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
-            QUnit.equal("[[3]]", JSON.stringify(cursor.currentPageOrderedEntries), "check currentPageOrderedEntries");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST smart query with compare on integer field
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithIntegerCompare  = function() {
-
-    var self = this;
-    var myEntry1 = { Name: "A", rank:1 };
-    var myEntry2 = { Name: "B", rank:2 };
-    var myEntry3 = { Name: "C", rank:3 };
-    var myEntry4 = { Name: "D", rank:4 };
-    var myEntry5 = { Name: "E", rank:5 };
-    var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4, myEntry5];
-    var soupName = "alphabetSoup";
-
-    var pluckNames = function(cursor) {
-        var names = "";
-        for (var i=0; i<cursor.currentPageOrderedEntries.length; i++) {
-            names += cursor.currentPageOrderedEntries[i][0].Name;
-        }
-        return names;
+    /**
+     * Constructor for SmartStoreTestSuite
+     */
+    var SmartStoreTestSuite = function () {
+        AbstractSmartStoreTestSuite.call(this, 
+                                         "smartstore", 
+                                         [
+                                             {path:"Name", type:"string"}, 
+                                             {path:"Id", type:"string"}
+                                         ]);
+
+        // To run specific tests
+        // this.testsToRun = ["testSmartQueryWithIntegerCompare"];
     };
 
-    var buildQuerySpec = function(comparison) {
-        var smartQuery = "select {alphabetSoup:_soup} from {alphabetSoup} where {alphabetSoup:rank} " + comparison + " order by lower({alphabetSoup:Name})";
-        return navigator.smartstore.buildSmartQuerySpec(smartQuery, 5);
+    // We are sub-classing AbstractSmartStoreTestSuite
+    SmartStoreTestSuite.prototype = new AbstractSmartStoreTestSuite();
+    SmartStoreTestSuite.prototype.constructor = SmartStoreTestSuite;
+
+
+    /**
+     * Helper method that adds three soup entries to default soup
+     */
+    SmartStoreTestSuite.prototype.stuffTestSoup = function() {
+        console.log("In SFSmartStoreTestSuite.stuffTestSoup");
+        var myEntry1 = { Name: "Todd Stellanova", Id: "00300A", attributes:{type:"Contact"}, department:"Engineering"};
+        var myEntry2 = { Name: "Pro Bono Bonobo",  Id: "00300B", attributes:{type:"Contact"}, department:"Biology"};
+        var myEntry3 = { Name: "Robot", Id: "00300C", attributes:{type:"Contact"}, department:"Engineering"};
+        var entries = [myEntry1, myEntry2, myEntry3];
+        return this.addEntriesToTestSoup(entries);
     };
 
-    self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"rank", type:"integer"}])
-        .pipe(function() {
-            return self.upsertSoupEntries(soupName,rawEntries);
-        })
-        .pipe(function(entries) {
-            return self.runSmartQuery(buildQuerySpec("!= 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "ABDE");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            return self.runSmartQuery(buildQuerySpec("= 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "C");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            return self.runSmartQuery(buildQuerySpec("< 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "AB");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            return self.runSmartQuery(buildQuerySpec("<= 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "ABC");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            return self.runSmartQuery(buildQuerySpec("> 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "DE");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            return self.runSmartQuery(buildQuerySpec(">= 3"));
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(pluckNames(cursor), "CDE");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
 
-/**
- * TEST smartQuery with a WHERE x LIKE y clause.
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithWhereLikeClause  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
-    var self = this;
-    var testEntries;
+    /** 
+     * TEST getDatabaseSize
+     */
+    SmartStoreTestSuite.prototype.testGetDatabaseSize  = function() {
+        console.log("In SFSmartStoreTestSuite.testGetDatabaseSize");
+        var self = this;
+        var initialSize;
+
+        // Start clean
+        self.getDatabaseSize()
+            .then(function(size) {
+                QUnit.ok(size > 0,"check getDatabaseSize result: " + size);
+                initialSize = size;
+                return self.addGeneratedEntriesToTestSoup(2000)
+            })
+            .then(function(entries) {
+                QUnit.equal(entries.length, 2000, "check addGeneratedEntriesToTestSoup result");
+                return self.getDatabaseSize();
+            })
+            .then(function(size) {
+                QUnit.ok(size > initialSize,"check getDatabaseSize result: " + size);
+                self.finalizeTest();
+            });
+    };
+
+    /** 
+     * TEST global store vs regular store with registerSoup / soupExists / removeSoup
+     */
+    SmartStoreTestSuite.prototype.testRegisterRemoveSoupGlobalStore = function()  {
+        console.log("In SFSmartStoreTestSuite.testRegisterRemoveSoupGlobalStore");
+        var soupName = "soupForTestRegisterRemoveSoupGlobalStore";
+
+        var self = this;
+        var GLOBAL_STORE = true;
+        var REGULAR_STORE = false;
+
+        // Start clean
+        Promise.all([self.removeSoup(REGULAR_STORE, soupName),
+                     self.removeSoup(GLOBAL_STORE, soupName)])
+            .then(function() {
+                // Check soup does not exist in either stores
+                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
+                                    self.soupExists(GLOBAL_STORE, soupName)]);
+            })
+            .then(function(result) {
+                var exists = result[0], existsGlobal = result[1];
+                QUnit.equals(exists, false, "soup should not already exist in regular store");
+                QUnit.equals(existsGlobal, false, "soup should not already exist in global store");
+                // Create soup in global store
+                return self.registerSoup(GLOBAL_STORE, soupName, self.defaultSoupIndexes);
+            })
+            .then(function(soupName2) {
+                QUnit.equals(soupName2,soupName,"registered soup OK in global store");
+                // Check soup exist only in global store
+                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
+                                    self.soupExists(GLOBAL_STORE, soupName)]);
+            })
+            .then(function(result) {
+                var exists = result[0], existsGlobal = result[1];
+                QUnit.equals(exists, false, "soup should not exist in regular store");
+                QUnit.equals(existsGlobal, true, "soup should now exist in global store");
+                // Create soup in regular store
+                return self.registerSoup(REGULAR_STORE, soupName, self.defaultSoupIndexes);
+            })
+            .then(function(soupName2) {
+                QUnit.equals(soupName2,soupName,"registered soup OK in regular store");
+                // Check soup exist only in both stores
+                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
+                                    self.soupExists(GLOBAL_STORE, soupName)]);
+            })
+            .then(function(result) {
+                var exists = result[0], existsGlobal = result[1];
+                QUnit.equals(exists, true, "soup should now exist in regular store");
+                QUnit.equals(existsGlobal, true, "soup should exist in global store");
+                // Remove soup from global store
+                return self.removeSoup(GLOBAL_STORE, soupName);
+            })
+            .then(function() {
+                // Check soup exist only in regular store
+                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
+                                    self.soupExists(GLOBAL_STORE, soupName)]);
+            })
+            .then(function(result) {
+                var exists = result[0], existsGlobal = result[1];
+                QUnit.equals(exists, true, "soup should still exist in regular store");
+                QUnit.equals(existsGlobal, false, "soup should no longer exist in global store");
+                // Remove soup from regular store
+                return self.removeSoup(REGULAR_STORE, soupName);
+            })
+            .then(function() {
+                // Check soup no longer exist in either store
+                return Promise.all([self.soupExists(REGULAR_STORE, soupName),
+                                    self.soupExists(GLOBAL_STORE, soupName)]);
+            })
+            .then(function(result) {
+                var exists = result[0], existsGlobal = result[1];
+                QUnit.equals(exists, false, "soup should no longer exist in regular store");
+                QUnit.equals(existsGlobal, false, "soup should no longer exist in global store");
+                self.finalizeTest();
+            });
+    };
     
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            testEntries = entries;
-            QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%bo%'", 10);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            var rows = cursor.currentPageOrderedEntries;
-            QUnit.equal(2, rows.length, "check number of rows returned");
-            var actualNames = [rows[0][0].Name, rows[1][0].Name];
-            actualNames.sort();
+    /** 
+     * TEST registerSoup / soupExists / removeSoup 
+     */
+    SmartStoreTestSuite.prototype.testRegisterRemoveSoup = function()  {
+        console.log("In SFSmartStoreTestSuite.testRegisterRemoveSoup");
+        var soupName = "soupForTestRegisterRemoveSoup";
 
-            // Should return 2nd and 3rd entries.
-            QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
-            QUnit.equal("Robot",  actualNames[1]);
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+        var self = this;
 
-/**
- * TEST smartQuery with a WHERE x LIKE y ORDER BY LOWER({z}) clause.
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithWhereLikeClauseOrdered  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
-    var self = this;
-    var testEntries;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            testEntries = entries;
-            QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%o%' ORDER BY LOWER({" + self.defaultSoupName + ":Name})", 10);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            var rows = cursor.currentPageOrderedEntries;
-            QUnit.equal(3, rows.length, "check number of rows returned");
-            var actualNames = [rows[0][0].Name, rows[1][0].Name, rows[2][0].Name];
+        // Start clean
+        self.removeSoup(soupName)
+            .then(function() {
+                // Check soup does not exist
+                return self.soupExists(soupName);
+            })
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should not already exist");
+                // Create soup
+                return self.registerSoup(soupName, self.defaultSoupIndexes);
+            })
+            .then(function(soupName2) {
+                QUnit.equals(soupName2,soupName,"registered soup OK");
+                // Check soup now exists
+                return self.soupExists(soupName);
+            }, function(err) {QUnit.ok(false,"self.registerSoup failed " + err);})
+            .then(function(exists) {
+                QUnit.equals(exists, true, "soup should now exist");
+                // Attempt to register the same soup again
+                return self.registerSoup(soupName, self.defaultSoupIndexes);
+            })
+            .then(function(soupName3) {
+                QUnit.equals(soupName3,soupName,"re-registered existing soup OK");
+                // Remove soup
+                return self.removeSoup(soupName);
+            }, function(err) {QUnit.ok(false,"re-registering existing soup failed " + err);})
+            .then(function() {
+                // Check soup no longer exists
+                return self.soupExists(soupName);
+            })
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should no longer exist");
+                self.finalizeTest();
+            });
+    }; 
 
-            // Should return all entries sorted
-            QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
-            QUnit.equal("Robot",  actualNames[1]);
-            QUnit.equal("Todd Stellanova", actualNames[2]);
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+    /** 
+     * TEST registerSoupWithSpec / getSoupSpec / removeSoup 
+     */
+    SmartStoreTestSuite.prototype.testRegisterWithSpec = function()  {
+        console.log("In SFSmartStoreTestSuite.testRegisterWithSpec");
+        var soupName = "soupForTestRegisterWithSpec";
 
-/**
- * TEST smartQuery SELECT a FROM c WHERE d IN (values) type clause.
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithSingleFieldAndWhereInClause  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
-    var self = this;
-    var testEntries;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            testEntries = entries;
-            QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300B')", 10);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
-            QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+        var self = this;
 
-            // Should return 1st and 2nd entries.
-            QUnit.equal(JSON.stringify([testEntries[0].Name]), JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
-            QUnit.equal(JSON.stringify([testEntries[1].Name]), JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+        // Start clean
+        self.removeSoup(soupName)
+            .then(function() {
+                // Check soup does not exist
+                return self.soupExists(soupName);
+            })
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should not already exist");
+                // Create soup
+                return self.registerSoupWithSpec({name:soupName, features:["externalStorage"]}, self.defaultSoupIndexes);
+            })
+            .then(function(soupName2) {
+                QUnit.equals(soupName2,soupName,"registered soup OK");
+                // Check soup now exists
+                return self.soupExists(soupName);
+            }, function(err) {QUnit.ok(false,"self.registerSoupWithSpec failed " + err);})
+            .then(function(exists) {
+                QUnit.equals(exists, true, "soup should now exist");
+                // Check soup spec
+                return self.checkSoupSpec(soupName, {name:soupName, features:["externalStorage"]});
+            })
+            .then(function() {
+                // Remove soup
+                return self.removeSoup(soupName);
+            }, function(err) {QUnit.ok(false,"self.getSoupSpec failed " + err);})
+            .then(function() {
+                // Check soup no longer exists
+                return self.soupExists(soupName);
+            })
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should no longer exist");
+                self.finalizeTest();
+            });
+    }; 
 
-/**
- * TEST smartQuery SELECT a, b FROM c WHERE d IN (values) type clause.
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithMultipleFieldsAndWhereInClause  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
-    var self = this;
-    var testEntries;
-    
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            testEntries = entries;
-            QUnit.equal(entries.length, 3, "check stuffTestSoup result");
-            var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name}, {" + self.defaultSoupName + ":Id} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300C')", 10);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
-            QUnit.equal(2, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
 
-            // Should return 1st and 3rd entries.
-            QUnit.equal(JSON.stringify([testEntries[0].Name, testEntries[0].Id]), 
-                JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
-            QUnit.equal(JSON.stringify([testEntries[2].Name, testEntries[2].Id]), 
-                JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+    /** 
+     * TEST registerSoup with bogus soup
+     */
+    SmartStoreTestSuite.prototype.testRegisterBogusSoup = function()  {
+        console.log("In SFSmartStoreTestSuite.testRegisterBogusSoup");
+        var soupName = null;//intentional bogus soupName
+        var self = this;
 
-/**
- * TEST query with special field
- */
-SmartStoreTestSuite.prototype.testSmartQueryWithSpecialFields  = function() {
-    console.log("In SFSmartStoreTestSuite.testSmartQueryWithSpecialFields");
-    var self = this;
-    var expectedEntry;
-    
-    if (window.mockStore) {
-        // Mock smartstore doesn't support such queries
-        self.finalizeTest();
-        return;
+        self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes)
+            .then(function(soupName2) {
+                self.setAssertionFailed("registerSoup should fail with bogus soupName " + soupName2);
+            })
+            .catch(function() {            
+                QUnit.ok(true,"registerSoup should fail with bogus soupName");
+                self.finalizeTest();
+            });
+    };
+
+
+    /** 
+     * TEST registerSoup with no indices
+     */
+    SmartStoreTestSuite.prototype.testRegisterSoupNoIndices = function()  {
+        console.log("In SFSmartStoreTestSuite.testRegisterSoupNoIndices");
+
+        var soupName = "soupForRegisterNoIndices";
+        var self = this;
+
+        // Start clean
+        self.removeSoup(soupName)
+            .then(function() {
+                // Check soup does not exist
+                return self.soupExists(soupName);
+            })
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should not already exist");
+                // Create soup
+                return self.registerSoupNoAssertion(soupName, []);
+            })
+            .then(function(soupName2) {
+                self.setAssertionFailed("registerSoup should fail with bogus indices " + soupName2);
+            })
+            .catch(function() {            
+                QUnit.ok(true,"registerSoup should fail with bogus indices");
+                self.finalizeTest();
+            });
     }
+
+    /** 
+     * TEST upsertSoupEntries 
+     */
+    SmartStoreTestSuite.prototype.testUpsertSoupEntries = function()  {
+        console.log("In SFSmartStoreTestSuite.testUpsertSoupEntries");
+
+        var self = this;
+        self.addGeneratedEntriesToTestSoup(7)
+            .then(function(entries1) {
+                QUnit.equal(entries1.length, 7);
+                
+                //upsert another batch
+                return self.addGeneratedEntriesToTestSoup(12);
+            })
+            .then(function(entries2) {
+                QUnit.equal(entries2.length, 12);
+                //modify the initial entries
+                for (var i = 0; i < entries2.length; i++) {
+                    var e = entries2[i];
+                    e.updatedField = "Mister Toast " + i;
+                }
+                
+                //update the entries
+                return self.addEntriesToTestSoup(entries2);
+            })
+            .then(function(entries3) {
+                QUnit.equal(entries3.length,12,"updated list match initial list len");
+                QUnit.equal(entries3[0].updatedField,"Mister Toast 0","updatedField is correct");
+                self.finalizeTest();
+            });
+    }; 
+
+    /** 
+     * TEST upsertSoupEntriesWithExternalId
+     */
+    SmartStoreTestSuite.prototype.testUpsertSoupEntriesWithExternalId = function()  {
+        console.log("In SFSmartStoreTestSuite.testUpsertSoupEntriesWithExternalId");
+
+        var self = this;
+        self.addGeneratedEntriesToTestSoup(11)
+            .then(function(entries1) {
+                QUnit.equal(entries1.length, 11);
+                
+                // Now upsert an overlapping batch, using an external ID path.
+                var entries2 = self.createGeneratedEntries(16);
+                for (var i = 0; i < entries2.length; i++) {
+                    var entry = entries2[i];
+                    entry.updatedField = "Mister Toast " + i;
+                }
+                var externalIdPath = self.defaultSoupIndexes[0].path;
+                return self.upsertEntriesToSoupWithExternalIdPath(self.defaultSoupName, entries2, externalIdPath);
+            })
+            .then(function(entries3) {
+                QUnit.equal(entries3.length, 16);
+                
+                // Now, query the soup for all entries, and make sure that we have only 16.
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", null, 25);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 16, "Are totalEntries correct?");
+                QUnit.equal(cursor.totalPages, 1, "Are totalPages correct?");
+                var orderedEntries = cursor.currentPageOrderedEntries;
+                var nEntries = orderedEntries.length;
+                QUnit.equal(nEntries, 16, "Are there 16 entries in total?");
+                QUnit.equal(orderedEntries[0]._soupEntryId, 1, "Is the first soup entry ID correct?");
+                QUnit.equal(orderedEntries[0].updatedField, "Mister Toast 0", "Is the first updated field correct?");
+                QUnit.equal(orderedEntries[15]._soupEntryId, 16, "Is the last soup entry ID correct?");
+                QUnit.equal(orderedEntries[15].updatedField, "Mister Toast 15", "Is the last updated field correct?");
+                
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    }; 
+
+
+    /** 
+     * TEST upsertSoupEntries to non existent soup
+     */
+    SmartStoreTestSuite.prototype.testUpsertToNonexistentSoup = function()  {
+        console.log("In SFSmartStoreTestSuite.testUpsertToNonexistentSoup");
+
+        var self = this;
+        var entries = [{a:1},{a:2},{a:3}];
+        
+        self.upsertSoupEntriesNoAssertion("nonexistentSoup", entries)
+            .then(function(upsertedEntries) {
+                self.setAssertionFailed("upsertSoupEntries should fail with nonexistent soup ");
+            })
+            .catch(function() {            
+                QUnit.ok(true,"upsertSoupEntries should fail with nonexistent soup");
+                self.finalizeTest();
+            });
+    };
     
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            expectedEntry = entries[0];
-            var sql = "select {" + self.defaultSoupName + ":_soup}, {" + self.defaultSoupName + ":_soupEntryId}, {" + self.defaultSoupName + ":_soupLastModifiedDate} from {" + self.defaultSoupName + "} where {" + self.defaultSoupName + ":Id} = '" + expectedEntry.Id + "'";
-            var querySpec = navigator.smartstore.buildSmartQuerySpec(sql, 1);
-            return self.runSmartQuery(querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
-            QUnit.equal(3, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0]._soupEntryId, expectedEntry._soupEntryId, "check _soup's soupEntryId returned");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0].Id, expectedEntry.Id, "check _soup's Id returned");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][0].Name, expectedEntry.Name, "check _soup's Name returned");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][1], expectedEntry._soupEntryId, "check _soupEntryId returned");
-            QUnit.equal(cursor.currentPageOrderedEntries[0][2], expectedEntry._soupLastModifiedDate, "check _soupLastModifieddate returned");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+    /**
+     * TEST retrieveSoupEntries 
+     */
+    SmartStoreTestSuite.prototype.testRetrieveSoupEntries = function()  {
+        console.log("In SFSmartStoreTestSuite.testRetrieveSoupEntries");
+        
+        var self = this; 
+        var soupEntry0Id;
+        var soupEntry2Id;
+
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                soupEntry0Id = entries[0]._soupEntryId;
+                soupEntry2Id = entries[2]._soupEntryId;
+                
+                return self.retrieveSoupEntries(self.defaultSoupName, [soupEntry2Id, soupEntry0Id]);
+            })
+            .then(function(retrievedEntries) {
+                QUnit.equal(retrievedEntries.length, 2);
+                
+                var entryIdArray = new Array();
+                for (var i = 0; i < retrievedEntries.length; i++) {
+                    entryIdArray[i] = retrievedEntries[i]._soupEntryId;
+                }
+                self.collectionContains(entryIdArray, soupEntry0Id);
+                self.collectionContains(entryIdArray, soupEntry2Id);
+                self.finalizeTest();
+            }); 
+    };
 
 
-/**
- * TEST getSoupIndexSpecs
- */
-SmartStoreTestSuite.prototype.testGetSoupIndexSpecs  = function() {
-    var soupName = "soupForGetSoupIndexSpecs";
-    var self = this;
+    /**
+     * TEST removeFromSoup by ids
+     */
+    SmartStoreTestSuite.prototype.testRemoveFromSoup = function()  {
+        console.log("In SFSmartStoreTestSuite.testRemoveFromSoup");    
+        
+        var self = this; 
+        self.stuffTestSoup()
+            .then(function(entries) {
+                var soupEntryIds = [];
+                QUnit.equal(entries.length, 3);
+                
+                for (var i = entries.length - 1; i >= 0; i--) {
+                    var entry = entries[i];
+                    soupEntryIds.push(entry._soupEntryId);
+                }
+                
+                return self.removeFromSoup(self.defaultSoupName, soupEntryIds);
+            })
+            .then(function(status) {
+                QUnit.equal(status, "OK", "removeFromSoup OK");
+                
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
 
-    // Start clean
-    self.removeSoup(soupName)
-        .pipe(function() {
-            // Create soup
-            return self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes);
-        })
-        .pipe(function(soupName2) {
-            QUnit.equals(soupName2,soupName,"registered soup OK");
-            // Checking soup indexes
-            return self.checkSoupIndexes(soupName, self.defaultSoupIndexes);
-        })
-        .done(function() {
-            self.finalizeTest();
-        });
-};
+    /**
+     * TEST removeFromSoup by query
+     */
+    SmartStoreTestSuite.prototype.testRemoveFromSoupByQuery = function()  {
+        console.log("In SFSmartStoreTestSuite.testRemoveFromSoupByQuery");    
+        
+        var self = this; 
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                var querySpecForRemove = navigator.smartstore.buildExactQuerySpec("Name", "Robot");
+                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+            })
+            .then(function(status) {
+                QUnit.equal(status, "OK", "removeFromSoup OK");
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify second entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                var querySpecForRemove = navigator.smartstore.buildLikeQuerySpec("Name", "%Stella%");
+                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+            })
+            .then(function(status) {
+                QUnit.equal(status, "OK", "removeFromSoup OK");
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Id", "ascending");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify only entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                var querySpecForRemove = navigator.smartstore.buildAllQuerySpec("Name");
+                return self.removeFromSoup(self.defaultSoupName, querySpecForRemove);
+            })
+            .then(function(status) {
+                QUnit.equal(status, "OK", "removeFromSoup OK");
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Id");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check currentPageOrderedEntries");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
 
-
-/**
- * TEST getSoupIndexSpecs with bogus soupName
- */
-SmartStoreTestSuite.prototype.testGetSoupIndexSpecsWithBogusSoupName  = function() {
-    var soupName = "soupForGetSoupIndexSpecsWithBogusSoupName";
-    var self = this;
-
-    // Check soup does not exist
-    self.soupExists(soupName)
-        .pipe(function(exists) {
-            QUnit.equals(exists, false, "soup should not already exist");
-            return self.getSoupIndexSpecsNoAssertion(soupName);
-        })
-        .done(function() {
-            self.setAssertionFailed("getSoupIndexSpecs with bogus soupName should fail");
-        })
-        .fail(function() {            
-            QUnit.ok(true,"getSoupIndexSpecs should fail for bogus soupName");
-            self.finalizeTest();
-        });
-};
-
-
-/**
- * TEST alterSoupNoReIndexing
- */
-SmartStoreTestSuite.prototype.testAlterSoupNoReIndexing  = function() {
-    this.tryAlterSoup(false);
-};
-
-/**
- * TEST alterSoupWithReIndexing
- */
-SmartStoreTestSuite.prototype.testAlterSoupWithReIndexing  = function() {
-    this.tryAlterSoup(true);
-};
-
-/**
- * TEST alterSoupWithSpecNoReIndexing
- */
-SmartStoreTestSuite.prototype.testAlterSoupWithSpecNoReIndexing  = function() {
-    this.tryAlterSoupWithSpec(false);
-};
-
-/**
- * TEST alterSoupWithSpecWithReIndexing
- */
-SmartStoreTestSuite.prototype.testAlterSoupWithSpecWithReIndexing  = function() {
-    this.tryAlterSoupWithSpec(true);
-};
-
-
-/**
- * Helper method for alterSoup tests
- */
-SmartStoreTestSuite.prototype.tryAlterSoup = function(reIndexData) {
-    var self = this;
-    var alteredIndexes = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
-
-    // Populate soup
-    return self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            // Alter soup
-            return self.alterSoup(self.defaultSoupName, alteredIndexes, reIndexData);
-        })
-        .pipe(function() {
-            // Checking altered soup indexes 
-            return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes);
-        })
-        .pipe(function() {
-            // Query by a new indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function() {
-            // Query by a previously indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * Helper method for alterSoupWithSpec tests
- * Alter the soup twice changing the storage type each time (internal -> external -> internal)
- */
-SmartStoreTestSuite.prototype.tryAlterSoupWithSpec = function(reIndexData) {
-    var self = this;
-    var alteredIndexes1 = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
-    var alteredSoupSpec1 = {name: self.defaultSoupName, features: ["externalStorage"]};
-    var alteredIndexes2 = [{path:"Name", type:"string"}, {path:"department", type:"string"}];
-    var alteredSoupSpec2 = {name: self.defaultSoupName, features: []};
-
-    // Populate soup
-    return self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            // Alter soup internal -> external
-            return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec1, alteredIndexes1, reIndexData);
-        })
-        .pipe(function() {
-            // Checking altered soup indexes 
-            return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes1);
-        })
-        .pipe(function() {
-            // Checking altered soup spec
-            return self.checkSoupSpec(self.defaultSoupName, alteredSoupSpec1);
-        })
-        .pipe(function() {
-            // Query by a new indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function() {
-            // Query by a previously indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            // Alter soup external -> internal
-            return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec2, alteredIndexes2, reIndexData);
-        })
-        .pipe(function() {
-            // Checking altered soup indexes 
-            return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes2);
-        })
-        .pipe(function() {
-            // Checking altered soup spec
-            return self.checkSoupSpec(self.defaultSoupName, alteredSoupSpec2);
-        })
-        .pipe(function() {
-            // Query by a new indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("department", "Engineering", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 2 : 0, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function() {
-            // Query by a previously indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST alterSoup with bogus soupName
- */
-SmartStoreTestSuite.prototype.testAlterSoupWithBogusSoupName  = function() {
-    var soupName = "soupForAlterSoupWithBogusSoupName";
-    var self = this;
-
-    // Check soup does not exist
-    self.soupExists(soupName)
-        .pipe(function(exists) {
-            QUnit.equals(exists, false, "soup should not already exist");
-            return self.alterSoupNoAssertion(soupName, [{path:"key", type:"string"}], true);
-        })
-        .done(function() {
-            self.setAssertionFailed("alterSoup with bogus soupName should fail");
-        })
-        .fail(function() {            
-            QUnit.ok(true,"alterSoup should fail for bogus soupName");
-            self.finalizeTest();
-        });
-};
-
-/**
- * TEST reIndexSoup
- */
-SmartStoreTestSuite.prototype.testReIndexSoup = function() {
-    var self = this;
-    var alteredIndexes = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
-
-    // Populate soup
-    return self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3,"check stuffTestSoup result");
-            // Alter soup
-            return self.alterSoup(self.defaultSoupName, alteredIndexes, false);
-        })
-        .pipe(function() {
-            // Checking altered soup indexes 
-            return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes);
-        })
-        .pipe(function() {
-            // Query by a new indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function(cursor) {
-            // Re-index soup
-            return self.reIndexSoup(self.defaultSoupName, ["attributes.type"]);
-        })
-        .pipe(function() {
-            // Query by a new indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .pipe(function() {
-            // Query by a previously indexed field
-            var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
-            self.finalizeTest();
-        });
-};
+    /**
+     * TEST querySoup with exact query
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupWithExactQuery = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupWithExactQuery"); 
+        
+        var self = this;
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 1, "wrong number of results");
+                QUnit.equal(cursor.currentPageOrderedEntries[0]["Name"], "Robot", "wrong name");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                // Now querying with select paths
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name","Robot",null,null,null,["Name", "Id"]);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 1, "wrong number of results");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0], "Robot", "wrong name");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][1], "00300C", "wrong id");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
 
 
-/**
- * Helper method checkSoupIndexes
- */
-SmartStoreTestSuite.prototype.checkSoupIndexes = function(soupName, expectedIndexes) {
-    return this.getSoupIndexSpecs(soupName)
-        .done(function(soupIndexes) {
-            QUnit.equals(soupIndexes.length, expectedIndexes.length, "Check number of soup indices");
-            for (i = 0; i< expectedIndexes.length; i++) {
-                QUnit.equals(soupIndexes[i].path, expectedIndexes[i].path, "Check path");
-                QUnit.equals(soupIndexes[i].type, expectedIndexes[i].type, "Check type");
-            }
-        });
-};
+    /**
+     * TEST querySoup with all query with descending sort order
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupWithAllQueryDescending = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupWithAllQueryDescending");   
+        
+        var self = this;
+        self.stuffTestSoup().
+            then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending");       
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify second entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[2].Name,"Pro Bono Bonobo","verify third entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                // Now querying with select paths
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name", "descending", null, ["Name", "Id"]);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 3, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Todd Stellanova","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1][0],"Robot","verify second entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[2][0],"Pro Bono Bonobo","verify third entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300A","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300C","verify second entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[2][1],"00300B","verify third entry");
 
-/**
- * Helper method checkSoupSpec
- */
-SmartStoreTestSuite.prototype.checkSoupSpec = function(soupName, expectedSoupSpec) {
-    return this.getSoupSpec(soupName)
-        .done(function(soupSpec) {
-            QUnit.equals(soupSpec.name, expectedSoupSpec.name, "Check soup name in soup spec");
-            QUnit.equals(soupSpec.features.length, expectedSoupSpec.features.length, "Check features in soup spec");
-            for (i = 0; i< expectedSoupSpec.features.length; i++) {
-                QUnit.equals(soupSpec.features[i], expectedSoupSpec.features[i], "Check feature");
-            }
-        });
-};
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST querySoup with range query using order path
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupWithRangeQueryWithOrderPath = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupWithRangeQueryWithOrderPath");   
+        
+        var self = this;
+        self.stuffTestSoup().
+            then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name");
+                // should match 00300A and 00300B but sort by name
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Id,"00300B","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Todd Stellanova","verify last entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Id,"00300A","verify last entry");
+
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                // Now querying with select paths
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("Id", null, "00300B", "ascending", 3, "Name", ["Name", "Id"]);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 2, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Pro Bono Bonobo","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1][0],"Todd Stellanova","verify second entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300B","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1][1],"00300A","verify second entry");
+
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST querySoup with bad query spec
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupBadQuerySpec = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupBadQuerySpec"); 
+        
+        var self = this;
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                
+                //query on a nonexistent index
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("bottlesOfBeer",99,null,"descending");             
+                
+                return self.querySoupNoAssertion(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                self.setAssertionFailed("querySoup with bogus querySpec should fail");
+            })
+            .catch(function(param) { 
+                QUnit.ok(true,"querySoup with bogus querySpec should fail");
+                self.finalizeTest();                
+            });
+    };
 
 
+    /**
+     * TEST querySoup  with an endKey and no beginKey
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupEndKeyNoBeginKey = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupEndKeyNoBeginKey"); 
+        var self = this;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                //keep in sync with stuffTestSoup
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("Name",null,"Robot");              
 
-/**
- * TEST clearSoup
- */
-SmartStoreTestSuite.prototype.testClearSoup = function()  {
-    console.log("In SFSmartStoreTestSuite.testClearSoup");    
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 2, "nEntries matches endKey");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Robot","verify last entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST querySoup  with beginKey and no endKey
+     */
+    SmartStoreTestSuite.prototype.testQuerySoupBeginKeyNoEndKey = function()  {
+        console.log("In SFSmartStoreTestSuite.testQuerySoupBeginKeyNoEndKey"); 
+        var self = this;
+
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                //keep in sync with stuffTestSoup
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("Name","Robot",null);              
+
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 2, "nEntries matches beginKey");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Robot","verify first entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST testManipulateCursor
+     */
+    SmartStoreTestSuite.prototype.testManipulateCursor = function()  {
+        console.log("In SFSmartStoreTestSuite.testManipulateCursor");  
+        var self = this;
+
+        var NUM_ENTRIES = 42;
+        var PAGE_SIZE = 20;
+        var LAST_PAGE_SIZE = NUM_ENTRIES % PAGE_SIZE; // 2
+        var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 3
+        
+        var checkPage = function(cursor, expectedPage) {
+            var expectedPageSize = (expectedPage < NUM_PAGES - 1 ? PAGE_SIZE : LAST_PAGE_SIZE);
+            var expectedIdOfFirstRowOnPage = "003" + self.padNumber(expectedPage*PAGE_SIZE, NUM_ENTRIES, "0");
+            var expectedIdOfLastRowOnPage = "003" + self.padNumber(expectedPage*PAGE_SIZE+expectedPageSize-1, NUM_ENTRIES, "0");
+
+            QUnit.equal(cursor.currentPageIndex, expectedPage, "currentPageIndex correct");
+            QUnit.equal(cursor.totalEntries, NUM_ENTRIES, "totalEntries correct");
+            QUnit.equal(cursor.totalPages, NUM_PAGES, "totalPages correct");
+            QUnit.equal(cursor.currentPageOrderedEntries.length, expectedPageSize, "pageSize correct");      
+            QUnit.equal(cursor.currentPageOrderedEntries[0].Id, expectedIdOfFirstRowOnPage , "pageSize correct");      
+            QUnit.equal(cursor.currentPageOrderedEntries[expectedPageSize-1].Id, expectedIdOfLastRowOnPage, "pageSize correct");      
+        };
+
+        self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
+            .then(function(entries) {
+                QUnit.equal(entries.length, NUM_ENTRIES);
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                checkPage(cursor, 0);
+                return self.moveCursorToNextPage(cursor);
+            })
+            .then(function(cursor) {
+                checkPage(cursor, 1);
+                return self.moveCursorToNextPage(cursor);
+            })
+            .then(function(cursor) {
+                checkPage(cursor, 2);
+                return self.moveCursorToPreviousPage(cursor);
+            })
+            .then(function(cursor) {
+                checkPage(cursor, 1);
+                return self.moveCursorToNextPage(cursor);
+            })
+            .then(function(cursor) {
+                checkPage(cursor, 2);
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST testMoveCursorToPreviousPageFromFirstPage
+     */
+    SmartStoreTestSuite.prototype.testMoveCursorToPreviousPageFromFirstPage = function()  {
+        console.log("In SFSmartStoreTestSuite.testMoveCursorToPreviousPageFromFirstPage");  
+        var self = this;
+
+        var NUM_ENTRIES = 8;
+        var PAGE_SIZE = 5;
+        var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 2
+        var cursor;
+        
+        self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
+            .then(function(entries) {
+                QUnit.equal(entries.length, NUM_ENTRIES);
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(c) {
+                cursor = c;
+                QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
+                return self.moveCursorToPreviousPageNoAssertion(cursor);
+            })
+            .catch(function(error) {
+                QUnit.ok(error.message.indexOf("moveCursorToPreviousPage") == 0, "error should be about moveCursorToPreviousPage")
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+
+    /**
+     * TEST testMoveCursorToNextPageFromLastPage
+     */
+    SmartStoreTestSuite.prototype.testMoveCursorToNextPageFromLastPage = function()  {
+        console.log("In SFSmartStoreTestSuite.testMoveCursorToNextPageFromLastPage");  
+        var self = this;
+
+        var NUM_ENTRIES = 8;
+        var PAGE_SIZE = 5;
+        var NUM_PAGES = Math.ceil(NUM_ENTRIES / PAGE_SIZE); // 2
+        var cursor;
+        
+        self.addGeneratedEntriesToTestSoup(NUM_ENTRIES)
+            .then(function(entries) {
+                QUnit.equal(entries.length, NUM_ENTRIES);
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name",null,PAGE_SIZE);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageIndex, 0, "currentPageIndex correct");
+                return self.moveCursorToNextPage(cursor);
+            })
+            .then(function(c) {
+                cursor = c;
+                QUnit.equal(cursor.currentPageIndex, 1, "currentPageIndex correct");
+                return self.moveCursorToNextPageNoAssertion(cursor);
+            })
+            .catch(function(error) {
+                QUnit.ok(error.message.indexOf("moveCursorToNextPage") == 0, "error should be about moveCursorToNextPage");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) {
+                 QUnit.ok(true,"closeCursor ok"); 
+                 self.finalizeTest(); 
+            });
+    };
+
+
+    /**
+     * TEST unusual soup names
+     */
+    SmartStoreTestSuite.prototype.testArbitrarySoupNames = function() {
+        console.log("In SFSmartStoreTestSuite.testArbitrarySoupNames");    
+        var self = this;
+        var soupName = "123This should-be a_valid.soup+name!?100";
+        
+        //simply register and verify that the soup exists
+        self.removeAndRecreateSoup(soupName,self.defaultSoupIndexes).
+            then(function() {
+                self.finalizeTest();
+            });
+    };
+
+
+    /**
+     * TEST querySpec factory functions
+     */
+    SmartStoreTestSuite.prototype.testQuerySpecFactories = function() {
+        console.log("In SFSmartStoreTestSuite.testQuerySpecFactories");
+        var self = this;
+        
+        var path = "Name";
+        var matchKey = "matchKeyValue";
+        var beginKey = "beginKeyValue";
+        var endKey = "endKeyValue";
+        var order = "descending";
+        var pageSize = 17;
+        var orderPath = "orderPathValue";
+        var selectPaths = ["x","y"];
+
+        // Exact query with all args
+        var query =  navigator.smartstore.buildExactQuerySpec(path,matchKey,pageSize,order,orderPath,selectPaths);
+        QUnit.equal(query.queryType,"exact","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.matchKey,matchKey,"check matchKey");
+        QUnit.equal(query.order,order, "check order");
+        QUnit.equal(query.pageSize,pageSize,"check pageSize");
+        QUnit.equal(query.orderPath,orderPath,"check orderPath");
+        QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
+
+        // Exact query with min args
+        query = navigator.smartstore.buildExactQuerySpec(path,matchKey);
+        QUnit.equal(query.queryType,"exact","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.matchKey,matchKey,"check matchKey");
+        QUnit.equal(query.pageSize,10,"check pageSize");
+        QUnit.equal(query.order,"ascending", "check order");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.ok(query.selectPaths == null,"check selectPaths");    
+        
+        // Range query with all args
+        query = navigator.smartstore.buildRangeQuerySpec(path,beginKey,endKey,order,pageSize,orderPath,selectPaths);
+        QUnit.equal(query.queryType,"range","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.beginKey,beginKey,"check beginKey");
+        QUnit.equal(query.endKey,endKey,"check endKey");
+        QUnit.equal(query.order,order,"check order");
+        QUnit.equal(query.pageSize,pageSize,"check pageSize");
+        QUnit.equal(query.orderPath,orderPath,"check orderPath");
+        QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
+
+        // Range query with min args
+        query = navigator.smartstore.buildRangeQuerySpec(path,beginKey);
+        QUnit.equal(query.queryType,"range","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.beginKey,beginKey,"check beginKey");
+        QUnit.ok(query.endKey == null,"check endKey");
+        QUnit.equal(query.order,"ascending", "check order");
+        QUnit.equal(query.pageSize,10,"check pageSize");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.ok(query.selectPaths == null,"check selectPaths");    
+        
+        // Like query with all args
+        query = navigator.smartstore.buildLikeQuerySpec(path,beginKey,order,pageSize,orderPath,selectPaths);
+        QUnit.equal(query.queryType,"like","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.likeKey,beginKey,"check likeKey");
+        QUnit.equal(query.order,order,"check order");
+        QUnit.equal(query.pageSize,pageSize,"check pageSize");
+        QUnit.equal(query.orderPath,orderPath,"check orderPath");
+        QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
+        
+        // Like query with min args
+        query = navigator.smartstore.buildLikeQuerySpec(path,beginKey);
+        QUnit.equal(query.queryType,"like","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.likeKey,beginKey,"check likeKey");
+        QUnit.equal(query.order,"ascending", "check order");
+        QUnit.equal(query.pageSize,10,"check pageSize");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.ok(query.selectPaths == null,"check selectPaths");    
+        
+        // All query with all args
+        query = navigator.smartstore.buildAllQuerySpec(path,order,pageSize,selectPaths);
+        QUnit.equal(query.queryType,"range","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.equal(query.order,order,"check order");
+        QUnit.equal(query.pageSize,pageSize,"check pageSize");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
+
+        // All query with min args
+        query = navigator.smartstore.buildAllQuerySpec(path);
+        QUnit.equal(query.queryType,"range","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.equal(query.order,"ascending", "check order");
+        QUnit.equal(query.pageSize,10,"check pageSize");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.ok(query.selectPaths == null,"check selectPaths");    
+
+        // Match query with all args
+        query = navigator.smartstore.buildMatchQuerySpec(path, matchKey, order, pageSize, orderPath, selectPaths);
+        QUnit.equal(query.queryType,"match","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.matchKey,matchKey,"check matchKey");
+        QUnit.equal(query.order,order,"check order");
+        QUnit.equal(query.pageSize,pageSize,"check pageSize");
+        QUnit.equal(query.orderPath,orderPath,"check orderPath");
+        QUnit.equal(JSON.stringify(query.selectPaths),JSON.stringify(selectPaths),"check selectPaths");
+        
+        // Match query with min args
+        query = navigator.smartstore.buildMatchQuerySpec(path, matchKey);
+        QUnit.equal(query.queryType,"match","check queryType");
+        QUnit.equal(query.indexPath,path,"check indexPath");
+        QUnit.equal(query.matchKey,matchKey,"check matchKey");
+        QUnit.equal(query.order,"ascending", "check order");
+        QUnit.equal(query.pageSize,10,"check pageSize");
+        QUnit.equal(query.orderPath,path,"check orderPath");
+        QUnit.ok(query.selectPaths == null,"check selectPaths");    
+        
+        self.finalizeTest();
+    };
+
+    /**
+     * TEST like query starts with
+     */
+    SmartStoreTestSuite.prototype.testLikeQuerySpecStartsWith  = function() {
+        console.log("In SFSmartStoreTestSuite.testLikeQuerySpecStartsWith");
+        var self = this;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                // Now querying with select paths
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","Todd%", null, null, null, ["Name", "Id"]);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.totalEntries, 1, "totalEntries correct");
+                QUnit.equal(cursor.totalPages, 1, "totalPages correct");
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0],"Todd Stellanova","verify second entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][1],"00300A","verify second entry");
+
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+
+    /**
+     * TEST like query ends with
+     */
+    SmartStoreTestSuite.prototype.testLikeQuerySpecEndsWith  = function() {
+        console.log("In SFSmartStoreTestSuite.testLikeQuerySpecEndsWith");
+        var self = this;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%Stellanova");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST like query inner text
+     */
+    SmartStoreTestSuite.prototype.testLikeQueryInnerText  = function() {
+        console.log("In SFSmartStoreTestSuite.testLikeQueryInnerText");
+        var self = this;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("Name","%ono%");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 1, "currentPageOrderedEntries correct");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Pro Bono Bonobo","verify entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST full-text search
+     */
+    SmartStoreTestSuite.prototype.testFullTextSearch  = function() {
+        console.log("In SFSmartStoreTestSuite.testFullTextSearch");
+        var self = this;
+        var myEntry1 = { name: "elephant", description:"large mammals", colors:"grey"};
+        var myEntry2 = { name: "cat", description:"small mammals", colors:"black tabby white"};
+        var myEntry3 = { name: "dog", description:"medium mammals", colors:"grey black"};
+        var myEntry4 = { name: "lizard", description:"small reptilian", colors:"black green white"};
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
+        var soupName = "animals";
+
+        self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"description", type:"full_text"}, {path:"colors", type:"full_text"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                // Searching across fields with one term
+                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "grey", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
+            })
+            .then(function() {
+                // Searching across fields with multiple terms
+                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "small black", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["lizard", "cat"]);
+            })
+            .then(function() {
+                // Searching across fields with one term starred
+                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr*", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
+            })
+            .then(function() {
+                // Searching across fields with multiple terms one being negated
+                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "black NOT tabby", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
+            })
+            .then(function() {
+                // Searching across fields with multiple terms (one starred, one negated)
+                var querySpec = navigator.smartstore.buildMatchQuerySpec(null, "gr* NOT small", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
+            })
+            .then(function(entries) {
+                // Searching one field with one term
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "grey");
+                return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
+            })
+            .then(function() {
+                // Searching one field with multiple terms
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "white black", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
+            })
+            .then(function() {
+                // Searching one field with one term starred
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "gr*", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
+            })
+            .then(function() {
+                // Searching one field with multiple terms one being negated
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("colors", "black NOT tabby", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
+            })
+            .then(function() {
+                // Searching one with multiple terms (one starred, one negated)
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("description", "m* NOT small", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant"]);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    SmartStoreTestSuite.prototype.tryQuery = function(soupName, querySpec, expectedNames) {
+        var self = this;
+        return self.querySoup(soupName, querySpec)
+            .then(function(cursor) {
+                var results = cursor.currentPageOrderedEntries;
+                QUnit.equal(results.length, expectedNames.length, "check currentPageOrderedEntries when trying match '" + querySpec.matchKey + "'");
+                for (var i=0; i<results.length; i++) {
+                    QUnit.equal(results[i].name,expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "'");
+                }
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) {
+                // Now running query with select paths
+                var querySpecWithSelectPaths= JSON.parse(JSON.stringify(querySpec));
+                querySpecWithSelectPaths.selectPaths = ["name", "name"];
+                return self.querySoup(soupName, querySpecWithSelectPaths);
+            })
+            .then(function(cursor) {
+                var results = cursor.currentPageOrderedEntries;
+                QUnit.equal(results.length, expectedNames.length, "check currentPageOrderedEntries when trying match '" + querySpec.matchKey + "' with select paths param");
+                for (var i=0; i<results.length; i++) {
+                    QUnit.equal(results[i][0],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
+                    QUnit.equal(results[i][1],expectedNames[i],"verify that entry " + i + " is " + expectedNames[i] + " when trying match '" + querySpec.matchKey + "' with select paths param");
+                }
+                return self.closeCursor(cursor);
+            })
+    };
+
+    /**
+     * TEST full-text search against array node
+     */
+    SmartStoreTestSuite.prototype.testFullTextSearchAgainstArrayNode  = function() {
+        console.log("In SFSmartStoreTestSuite.testFullTextSearchAgainstArrayNode");
+        var self = this;
+        var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
+        var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
+        var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
+        var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
+        var soupName = "fullTextSearchAgainstArrayNodeSoup";
+
+        self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"full_text"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "grey", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
+            })
+            .then(function() {
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "white black", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["cat", "lizard"]);
+            })
+            .then(function() {
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "gr*", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
+            })
+            .then(function() {
+                var querySpec = navigator.smartstore.buildMatchQuerySpec("attributes.color", "black NOT tabby", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["lizard", "dog"]);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST like query against array node
+     */
+    SmartStoreTestSuite.prototype.testLikeQueryAgainstArrayNode  = function() {
+        console.log("In SFSmartStoreTestSuite.testLikeQueryAgainstArrayNode");
+        var self = this;
+        var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
+        var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
+        var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
+        var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
+        var soupName = "likeQueryAgainstArrayNodeSoup";
+
+        self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%grey%", "descending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["elephant", "dog"]);
+            })
+            .then(function() {
+                var querySpec = navigator.smartstore.buildLikeQuerySpec("attributes.color", "%gr%", "ascending", 10, "name");
+                return self.tryQuery(soupName, querySpec, ["dog", "elephant", "lizard"]);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST exact query against array node
+     */
+    SmartStoreTestSuite.prototype.testExactQueryAgainstArrayNode  = function() {
+        console.log("In SFSmartStoreTestSuite.testExactQueryAgainstArrayNode");
+        var self = this;
+        var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
+        var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
+        var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
+        var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
+        var soupName = "exactQueryAgainstArrayNodeSoup";
+
+        self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.color", "[\"grey\"]");
+                return self.tryQuery(soupName, querySpec, ["elephant"]);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smart query against array node
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryAgainstArrayNode  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryAgainstArrayNode");
+        var self = this;
+        var myEntry1 = { name: "elephant", attributes:[{color: "grey"}] };
+        var myEntry2 = { name: "cat", attributes:[{color: "black"}, {color: "tabby"}, {color: "white"}] };
+        var myEntry3 = { name: "dog", attributes:[{color: "black"}, {color: "grey"}] };
+        var myEntry4 = { name: "lizard", attributes:[{color: "black"}, {color: "green"}, {color: "white"}] };
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4];
+        var soupName = "smartQueryAgainstArrayNodeSoup";
+
+        self.removeAndRecreateSoup(soupName, [{path:"name", type:"string"},  {path:"attributes.color", type:"string"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + soupName + ":_soup} FROM {" + soupName + "} where {" + soupName + ":attributes.color} LIKE '%grey%' ORDER BY LOWER({" + soupName + ":name})" , 5);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
+                QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+                QUnit.equal("dog", cursor.currentPageOrderedEntries[0][0].name, "check first row");
+                QUnit.equal("elephant", cursor.currentPageOrderedEntries[1][0].name, "check second row");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
     
-    var self = this; 
-    self.stuffTestSoup()
-        .pipe(function(entries) {
-            QUnit.equal(entries.length, 3);
-            return self.clearSoup(self.defaultSoupName);
-        })
-        .pipe(function(status) {
-            QUnit.equal(status, "OK", "clearSoup OK");
-            
-            var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
-            return self.querySoup(self.defaultSoupName, querySpec);
-        })
-        .pipe(function(cursor) {
-            var nEntries = cursor.currentPageOrderedEntries.length;
-            QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
-            return self.closeCursor(cursor);
-        })
-        .done(function(param) { 
-            QUnit.ok(true,"closeCursor ok"); 
+    /**
+     * TEST query with compound path
+     */
+    SmartStoreTestSuite.prototype.testCompoundQueryPath  = function() {
+        console.log("In SFSmartStoreTestSuite.testCompoundQueryPath");
+        var self = this;
+        //attributes.url is a nonsensical path but it works for testing compound paths
+        var indices = [{path:"Name", type:"string"}, {path:"Id", type:"string"}, {path:"attributes.url", type:"string"}];
+        var soupName = "compoundPathSoup";
+        var selectedUrl;
+        self.removeAndRecreateSoup(soupName,indices)
+            .then(function() {
+                return self.addGeneratedEntriesToSoup(soupName, 3);
+            })
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check addGeneratedEntriesToSoup result");
+                //pick out a compound path value and ensure that we can query for the same entry
+                var selectedEntry = entries[1];
+                selectedUrl = selectedEntry.attributes.url;
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.url",selectedUrl);
+                return self.querySoup(soupName, querySpec); 
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "currentPageOrderedEntries correct");
+                var foundEntry = cursor.currentPageOrderedEntries[0];
+                QUnit.equal(foundEntry.attributes.url,selectedUrl,"Verify same entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest(); 
+            });
+    };
+
+    /**
+     * TEST query with empty query spec
+     */
+    SmartStoreTestSuite.prototype.testEmptyQuerySpec  = function() {
+        console.log("In SFSmartStoreTestSuite.testEmptyQuerySpec");
+        var self = this;
+        
+        var querySpec = new QuerySpec(null);
+        querySpec.queryType = null; 
+        self.querySoupNoAssertion(self.defaultSoupName, querySpec)
+            .then(function(param) { 
+                self.setAssertionFailed("querySoup should have failed"); 
+            })
+            .catch(function(param) { 
+                self.finalizeTest(); 
+            });
+    };
+
+
+    /**
+     * TEST query against integer field
+     */
+    SmartStoreTestSuite.prototype.testIntegerQuerySpec  = function() {
+        console.log("In SFSmartStoreTestSuite.testIntegerQuerySpec");
+        var self = this;
+        var myEntry1 = { Name: "Todd Stellanova", shots:37 };
+        var myEntry2 = { Name: "Pro Bono Bonobo",  shots:92  };
+        var myEntry3 = { Name: "Robot",  shots:0  };
+        var rawEntries = [myEntry1, myEntry2, myEntry3];
+        var soupName = "charmingSoup";
+
+        self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"shots", type:"integer"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                var querySpec = navigator.smartstore.buildRangeQuerySpec("shots", 10, 100,"ascending");
+                return self.querySoup(soupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 2, "check currentPageOrderedEntries");
+                QUnit.equal(cursor.currentPageOrderedEntries[0].Name,"Todd Stellanova","verify first entry");
+                QUnit.equal(cursor.currentPageOrderedEntries[1].Name,"Pro Bono Bonobo","verify last entry");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smart query with count
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithCount  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
+        var self = this;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("select count(*) from {" + self.defaultSoupName + "}", 1);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
+                QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+                QUnit.equal("[[3]]", JSON.stringify(cursor.currentPageOrderedEntries), "check currentPageOrderedEntries");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smart query with compare on integer field
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithIntegerCompare  = function() {
+
+        var self = this;
+        var myEntry1 = { Name: "A", rank:1 };
+        var myEntry2 = { Name: "B", rank:2 };
+        var myEntry3 = { Name: "C", rank:3 };
+        var myEntry4 = { Name: "D", rank:4 };
+        var myEntry5 = { Name: "E", rank:5 };
+        var rawEntries = [myEntry1, myEntry2, myEntry3, myEntry4, myEntry5];
+        var soupName = "alphabetSoup";
+
+        var pluckNames = function(cursor) {
+            var names = "";
+            for (var i=0; i<cursor.currentPageOrderedEntries.length; i++) {
+                names += cursor.currentPageOrderedEntries[i][0].Name;
+            }
+            return names;
+        };
+
+        var buildQuerySpec = function(comparison) {
+            var smartQuery = "select {alphabetSoup:_soup} from {alphabetSoup} where {alphabetSoup:rank} " + comparison + " order by lower({alphabetSoup:Name})";
+            return navigator.smartstore.buildSmartQuerySpec(smartQuery, 5);
+        };
+
+        self.removeAndRecreateSoup(soupName, [{path:"Name", type:"string"}, {path:"rank", type:"integer"}])
+            .then(function() {
+                return self.upsertSoupEntries(soupName,rawEntries);
+            })
+            .then(function(entries) {
+                return self.runSmartQuery(buildQuerySpec("!= 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "ABDE");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                return self.runSmartQuery(buildQuerySpec("= 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "C");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                return self.runSmartQuery(buildQuerySpec("< 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "AB");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                return self.runSmartQuery(buildQuerySpec("<= 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "ABC");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                return self.runSmartQuery(buildQuerySpec("> 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "DE");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                return self.runSmartQuery(buildQuerySpec(">= 3"));
+            })
+            .then(function(cursor) {
+                QUnit.equal(pluckNames(cursor), "CDE");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smartQuery with a WHERE x LIKE y clause.
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithWhereLikeClause  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
+        var self = this;
+        var testEntries;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                testEntries = entries;
+                QUnit.equal(entries.length, 3, "check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%bo%'", 10);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                var rows = cursor.currentPageOrderedEntries;
+                QUnit.equal(2, rows.length, "check number of rows returned");
+                var actualNames = [rows[0][0].Name, rows[1][0].Name];
+                actualNames.sort();
+
+                // Should return 2nd and 3rd entries.
+                QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
+                QUnit.equal("Robot",  actualNames[1]);
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smartQuery with a WHERE x LIKE y ORDER BY LOWER({z}) clause.
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithWhereLikeClauseOrdered  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
+        var self = this;
+        var testEntries;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                testEntries = entries;
+                QUnit.equal(entries.length, 3, "check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":_soup} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Name} LIKE '%o%' ORDER BY LOWER({" + self.defaultSoupName + ":Name})", 10);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                var rows = cursor.currentPageOrderedEntries;
+                QUnit.equal(3, rows.length, "check number of rows returned");
+                var actualNames = [rows[0][0].Name, rows[1][0].Name, rows[2][0].Name];
+
+                // Should return all entries sorted
+                QUnit.equal("Pro Bono Bonobo",  actualNames[0]);
+                QUnit.equal("Robot",  actualNames[1]);
+                QUnit.equal("Todd Stellanova", actualNames[2]);
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smartQuery SELECT a FROM c WHERE d IN (values) type clause.
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithSingleFieldAndWhereInClause  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
+        var self = this;
+        var testEntries;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                testEntries = entries;
+                QUnit.equal(entries.length, 3, "check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300B')", 10);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
+                QUnit.equal(1, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+
+                // Should return 1st and 2nd entries.
+                QUnit.equal(JSON.stringify([testEntries[0].Name]), JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
+                QUnit.equal(JSON.stringify([testEntries[1].Name]), JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST smartQuery SELECT a, b FROM c WHERE d IN (values) type clause.
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithMultipleFieldsAndWhereInClause  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithCount");
+        var self = this;
+        var testEntries;
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                testEntries = entries;
+                QUnit.equal(entries.length, 3, "check stuffTestSoup result");
+                var querySpec = navigator.smartstore.buildSmartQuerySpec("SELECT {" + self.defaultSoupName + ":Name}, {" + self.defaultSoupName + ":Id} FROM {" + self.defaultSoupName + "} WHERE {" + self.defaultSoupName + ":Id} IN ('00300A', '00300C')", 10);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(2, cursor.currentPageOrderedEntries.length, "check number of rows returned");
+                QUnit.equal(2, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+
+                // Should return 1st and 3rd entries.
+                QUnit.equal(JSON.stringify([testEntries[0].Name, testEntries[0].Id]), 
+                            JSON.stringify(cursor.currentPageOrderedEntries[0]), "check currentPageOrderedEntries[0]");
+                QUnit.equal(JSON.stringify([testEntries[2].Name, testEntries[2].Id]), 
+                            JSON.stringify(cursor.currentPageOrderedEntries[1]), "check currentPageOrderedEntries[1]");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST query with special field
+     */
+    SmartStoreTestSuite.prototype.testSmartQueryWithSpecialFields  = function() {
+        console.log("In SFSmartStoreTestSuite.testSmartQueryWithSpecialFields");
+        var self = this;
+        var expectedEntry;
+        
+        if (window.mockStore) {
+            // Mock smartstore doesn't support such queries
             self.finalizeTest();
-       });
-};
+            return;
+        }
+        
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                expectedEntry = entries[0];
+                var sql = "select {" + self.defaultSoupName + ":_soup}, {" + self.defaultSoupName + ":_soupEntryId}, {" + self.defaultSoupName + ":_soupLastModifiedDate} from {" + self.defaultSoupName + "} where {" + self.defaultSoupName + ":Id} = '" + expectedEntry.Id + "'";
+                var querySpec = navigator.smartstore.buildSmartQuerySpec(sql, 1);
+                return self.runSmartQuery(querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(1, cursor.currentPageOrderedEntries.length, "check number of rows returned");
+                QUnit.equal(3, cursor.currentPageOrderedEntries[0].length, "check number of fields returned");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0]._soupEntryId, expectedEntry._soupEntryId, "check _soup's soupEntryId returned");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0].Id, expectedEntry.Id, "check _soup's Id returned");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][0].Name, expectedEntry.Name, "check _soup's Name returned");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][1], expectedEntry._soupEntryId, "check _soupEntryId returned");
+                QUnit.equal(cursor.currentPageOrderedEntries[0][2], expectedEntry._soupLastModifiedDate, "check _soupLastModifieddate returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+
+    /**
+     * TEST getSoupIndexSpecs
+     */
+    SmartStoreTestSuite.prototype.testGetSoupIndexSpecs  = function() {
+        var soupName = "soupForGetSoupIndexSpecs";
+        var self = this;
+
+        // Start clean
+        self.removeSoup(soupName)
+            .then(function() {
+                // Create soup
+                return self.registerSoupNoAssertion(soupName, self.defaultSoupIndexes);
+            })
+            .then(function(soupName2) {
+                QUnit.equals(soupName2,soupName,"registered soup OK");
+                // Checking soup indexes
+                return self.checkSoupIndexes(soupName, self.defaultSoupIndexes);
+            })
+            .then(function() {
+                self.finalizeTest();
+            });
+    };
+
+
+    /**
+     * TEST getSoupIndexSpecs with bogus soupName
+     */
+    SmartStoreTestSuite.prototype.testGetSoupIndexSpecsWithBogusSoupName  = function() {
+        var soupName = "soupForGetSoupIndexSpecsWithBogusSoupName";
+        var self = this;
+
+        // Check soup does not exist
+        self.soupExists(soupName)
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should not already exist");
+                return self.getSoupIndexSpecsNoAssertion(soupName);
+            })
+            .then(function() {
+                self.setAssertionFailed("getSoupIndexSpecs with bogus soupName should fail");
+            })
+            .catch(function() {            
+                QUnit.ok(true,"getSoupIndexSpecs should fail for bogus soupName");
+                self.finalizeTest();
+            });
+    };
+
+
+    /**
+     * TEST alterSoupNoReIndexing
+     */
+    SmartStoreTestSuite.prototype.testAlterSoupNoReIndexing  = function() {
+        this.tryAlterSoup(false);
+    };
+
+    /**
+     * TEST alterSoupWithReIndexing
+     */
+    SmartStoreTestSuite.prototype.testAlterSoupWithReIndexing  = function() {
+        this.tryAlterSoup(true);
+    };
+
+    /**
+     * TEST alterSoupWithSpecNoReIndexing
+     */
+    SmartStoreTestSuite.prototype.testAlterSoupWithSpecNoReIndexing  = function() {
+        this.tryAlterSoupWithSpec(false);
+    };
+
+    /**
+     * TEST alterSoupWithSpecWithReIndexing
+     */
+    SmartStoreTestSuite.prototype.testAlterSoupWithSpecWithReIndexing  = function() {
+        this.tryAlterSoupWithSpec(true);
+    };
+
+
+    /**
+     * Helper method for alterSoup tests
+     */
+    SmartStoreTestSuite.prototype.tryAlterSoup = function(reIndexData) {
+        var self = this;
+        var alteredIndexes = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
+
+        // Populate soup
+        return self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                // Alter soup
+                return self.alterSoup(self.defaultSoupName, alteredIndexes, reIndexData);
+            })
+            .then(function() {
+                // Checking altered soup indexes 
+                return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes);
+            })
+            .then(function() {
+                // Query by a new indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function() {
+                // Query by a previously indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * Helper method for alterSoupWithSpec tests
+     * Alter the soup twice changing the storage type each time (internal -> external -> internal)
+     */
+    SmartStoreTestSuite.prototype.tryAlterSoupWithSpec = function(reIndexData) {
+        var self = this;
+        var alteredIndexes1 = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
+        var alteredSoupSpec1 = {name: self.defaultSoupName, features: ["externalStorage"]};
+        var alteredIndexes2 = [{path:"Name", type:"string"}, {path:"department", type:"string"}];
+        var alteredSoupSpec2 = {name: self.defaultSoupName, features: []};
+
+        // Populate soup
+        return self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                // Alter soup internal -> external
+                return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec1, alteredIndexes1, reIndexData);
+            })
+            .then(function() {
+                // Checking altered soup indexes 
+                return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes1);
+            })
+            .then(function() {
+                // Checking altered soup spec
+                return self.checkSoupSpec(self.defaultSoupName, alteredSoupSpec1);
+            })
+            .then(function() {
+                // Query by a new indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 3 : 0, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function() {
+                // Query by a previously indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                // Alter soup external -> internal
+                return self.alterSoupWithSpec(self.defaultSoupName, alteredSoupSpec2, alteredIndexes2, reIndexData);
+            })
+            .then(function() {
+                // Checking altered soup indexes 
+                return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes2);
+            })
+            .then(function() {
+                // Checking altered soup spec
+                return self.checkSoupSpec(self.defaultSoupName, alteredSoupSpec2);
+            })
+            .then(function() {
+                // Query by a new indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("department", "Engineering", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, reIndexData ? 2 : 0, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function() {
+                // Query by a previously indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST alterSoup with bogus soupName
+     */
+    SmartStoreTestSuite.prototype.testAlterSoupWithBogusSoupName  = function() {
+        var soupName = "soupForAlterSoupWithBogusSoupName";
+        var self = this;
+
+        // Check soup does not exist
+        self.soupExists(soupName)
+            .then(function(exists) {
+                QUnit.equals(exists, false, "soup should not already exist");
+                return self.alterSoupNoAssertion(soupName, [{path:"key", type:"string"}], true);
+            })
+            .then(function() {
+                self.setAssertionFailed("alterSoup with bogus soupName should fail");
+            })
+            .catch(function() {            
+                QUnit.ok(true,"alterSoup should fail for bogus soupName");
+                self.finalizeTest();
+            });
+    };
+
+    /**
+     * TEST reIndexSoup
+     */
+    SmartStoreTestSuite.prototype.testReIndexSoup = function() {
+        var self = this;
+        var alteredIndexes = [{path:"Name", type:"string"}, {path:"attributes.type", type:"string"}];
+
+        // Populate soup
+        return self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3,"check stuffTestSoup result");
+                // Alter soup
+                return self.alterSoup(self.defaultSoupName, alteredIndexes, false);
+            })
+            .then(function() {
+                // Checking altered soup indexes 
+                return self.checkSoupIndexes(self.defaultSoupName, alteredIndexes);
+            })
+            .then(function() {
+                // Query by a new indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 0, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(cursor) {
+                // Re-index soup
+                return self.reIndexSoup(self.defaultSoupName, ["attributes.type"]);
+            })
+            .then(function() {
+                // Query by a new indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("attributes.type", "Contact", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 3, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function() {
+                // Query by a previously indexed field
+                var querySpec = navigator.smartstore.buildExactQuerySpec("Name", "Robot", 3);
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                QUnit.equal(cursor.currentPageOrderedEntries.length, 1, "check number of rows returned");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
+
+
+    /**
+     * Helper method checkSoupIndexes
+     */
+    SmartStoreTestSuite.prototype.checkSoupIndexes = function(soupName, expectedIndexes) {
+        return this.getSoupIndexSpecs(soupName)
+            .then(function(soupIndexes) {
+                QUnit.equals(soupIndexes.length, expectedIndexes.length, "Check number of soup indices");
+                for (i = 0; i< expectedIndexes.length; i++) {
+                    QUnit.equals(soupIndexes[i].path, expectedIndexes[i].path, "Check path");
+                    QUnit.equals(soupIndexes[i].type, expectedIndexes[i].type, "Check type");
+                }
+            });
+    };
+
+    /**
+     * Helper method checkSoupSpec
+     */
+    SmartStoreTestSuite.prototype.checkSoupSpec = function(soupName, expectedSoupSpec) {
+        return this.getSoupSpec(soupName)
+            .then(function(soupSpec) {
+                QUnit.equals(soupSpec.name, expectedSoupSpec.name, "Check soup name in soup spec");
+                QUnit.equals(soupSpec.features.length, expectedSoupSpec.features.length, "Check features in soup spec");
+                for (i = 0; i< expectedSoupSpec.features.length; i++) {
+                    QUnit.equals(soupSpec.features[i], expectedSoupSpec.features[i], "Check feature");
+                }
+            });
+    };
+
+
+
+    /**
+     * TEST clearSoup
+     */
+    SmartStoreTestSuite.prototype.testClearSoup = function()  {
+        console.log("In SFSmartStoreTestSuite.testClearSoup");    
+        
+        var self = this; 
+        self.stuffTestSoup()
+            .then(function(entries) {
+                QUnit.equal(entries.length, 3);
+                return self.clearSoup(self.defaultSoupName);
+            })
+            .then(function(status) {
+                QUnit.equal(status, "OK", "clearSoup OK");
+                
+                var querySpec = navigator.smartstore.buildAllQuerySpec("Name");
+                return self.querySoup(self.defaultSoupName, querySpec);
+            })
+            .then(function(cursor) {
+                var nEntries = cursor.currentPageOrderedEntries.length;
+                QUnit.equal(nEntries, 0, "currentPageOrderedEntries correct");
+                return self.closeCursor(cursor);
+            })
+            .then(function(param) { 
+                QUnit.ok(true,"closeCursor ok"); 
+                self.finalizeTest();
+            });
+    };
 
 }
 

--- a/test/SFSmartStoreTestSuite.js
+++ b/test/SFSmartStoreTestSuite.js
@@ -113,7 +113,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equals(exists, false, "soup should not already exist in regular store");
                 QUnit.equals(existsGlobal, false, "soup should not already exist in global store");
                 // Create soup in global store
-                return self.smartstoreClient.registerSoup(GLOBAL_STORE, soupName, self.smartstoreClient.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(GLOBAL_STORE, soupName, self.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK in global store");
@@ -126,7 +126,7 @@ if (typeof SmartStoreTestSuite === 'undefined') {
                 QUnit.equals(exists, false, "soup should not exist in regular store");
                 QUnit.equals(existsGlobal, true, "soup should now exist in global store");
                 // Create soup in regular store
-                return self.smartstoreClient.registerSoup(REGULAR_STORE, soupName, self.smartstoreClient.defaultSoupIndexes);
+                return self.smartstoreClient.registerSoup(REGULAR_STORE, soupName, self.defaultSoupIndexes);
             })
             .then(function(soupName2) {
                 QUnit.equals(soupName2,soupName,"registered soup OK in regular store");

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -480,13 +480,13 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
     var querySpec007 = {queryType:"exact", indexPath:"Name", matchKey:"JamesBond", order:"ascending", pageSize:1}
     var querySpec008 = {queryType:"exact", indexPath:"Name", matchKey:"Vilain", order:"ascending", pageSize:1}
 
-    $.when(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
+    Promise.all(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
            Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName))
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, indexSpecs, null, REGULAR_STORE);
             cacheGlobal = new Force.StoreCache(soupName, indexSpecs, null, GLOBAL_STORE);
-            return $.when(cache.init(), cacheGlobal.init());
+            return Promise.all(cache.init(), cacheGlobal.init());
         })
         .then(function() {
             console.log("## Save record into regular cache");
@@ -494,7 +494,7 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
         })
         .then(function() {
             console.log("## Looking for record in both caches");
-            return $.when(cache.find(querySpec007), cacheGlobal.find(querySpec007));
+            return Promise.all(cache.find(querySpec007), cacheGlobal.find(querySpec007));
         })
         .then(function(result, resultGlobal) {
             console.log("## Checking result from regular cache");
@@ -507,7 +507,7 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
         })
         .then(function() {
             console.log("## Looking for record in both caches");
-            return $.when(cache.find(querySpec008), cacheGlobal.find(querySpec008));
+            return Promise.all(cache.find(querySpec008), cacheGlobal.find(querySpec008));
         })
         .then(function(result, resultGlobal) {
             console.log("## Checking result from regular cache");
@@ -518,7 +518,7 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
             console.log("## Save record into global cache");
 
             // Cleaning up 
-            return $.when(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
+            return Promise.all(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
                           Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName))
         })
         .then(function() {
@@ -673,7 +673,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeCacheOnlyMode = function() {
     .then(function() {
         console.log("## Calling describe layout");
         var sobjectType = new Force.SObjectType("MockObject", cache, Force.CACHE_MODE.CACHE_ONLY);
-        return $.when(sobjectType.describe(), sobjectType.getMetadata(), sobjectType.describeLayout());
+        return Promise.all(sobjectType.describe(), sobjectType.getMetadata(), sobjectType.describeLayout());
     })
     .then(function(descResult, metaResult, layoutResult) {
         assertContains(descResult, data.describeResult);
@@ -749,7 +749,7 @@ SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
         console.log("## Calling describe layout");
         var accountType = new Force.SObjectType("Account", cache);
         var contactType = new Force.SObjectType("Contact", cache);
-        return $.when(accountType.describe(), contactType.describe());
+        return Promise.all(accountType.describe(), contactType.describe());
     })
     .then(function(data1, data2) {
         accountDescribe = data1;
@@ -757,7 +757,7 @@ SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
         QUnit.equals('Account', accountDescribe.name, 'Describe result should be for Account');
         QUnit.equals('Contact', contactDescribe.name, 'Describe result should be for Contact');
         console.log("## Checking underlying cache");
-        return $.when(cache.retrieve("Account"), cache.retrieve("Contact"));
+        return Promise.all(cache.retrieve("Account"), cache.retrieve("Contact"));
     })
     .then(function(accountCache, contactCache) {    
         assertContains(accountDescribe, accountCache.describeResult);
@@ -789,7 +789,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeReset = function() {
     .then(function() { 
         console.log("## Calling getMetadata and describe");
         sobjectType = new Force.SObjectType("Account", cache);
-        return $.when(sobjectType.getMetadata(), sobjectType.describe());
+        return Promise.all(sobjectType.getMetadata(), sobjectType.describe());
     })
     .then(function() {
         console.log("## Checking underlying cache");
@@ -1302,7 +1302,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectCreate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -1385,7 +1385,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectRetrieve = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -1442,7 +1442,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectUpdate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -1502,7 +1502,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDelete = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -1527,12 +1527,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictCreate = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Trying create server-only");
@@ -1560,7 +1560,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictCreate = function() {
         })
         .then(function(data) {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals),
+            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals),
                           Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
 
         })
@@ -1581,12 +1581,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -1646,7 +1646,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -1664,12 +1664,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -1823,7 +1823,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -1841,12 +1841,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -2005,7 +2005,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2033,10 +2033,10 @@ SmartSyncTestSuite.prototype.testSObjectFetch = function() {
     var accountFetch = optionsPromiser(account, "fetch", "account");
     var id;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -2054,7 +2054,7 @@ SmartSyncTestSuite.prototype.testSObjectFetch = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2077,10 +2077,10 @@ SmartSyncTestSuite.prototype.testSObjectSave = function() {
     var accountSave = optionsPromiser(account, "save", "account");
     var id;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Trying save with default cacheMode and mergeMode");
@@ -2094,7 +2094,7 @@ SmartSyncTestSuite.prototype.testSObjectSave = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2117,10 +2117,10 @@ SmartSyncTestSuite.prototype.testSObjectDestroy = function() {
     var accountDestroy = optionsPromiser(account, "destroy", "account");
     var id;
 
-    $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() {
             console.log("## Trying destroy with default cacheMode and mergeMode");
@@ -2140,7 +2140,7 @@ SmartSyncTestSuite.prototype.testSObjectDestroy = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return $.when(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2430,7 +2430,7 @@ SmartSyncTestSuite.prototype.testFetchSObjects = function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2512,7 +2512,7 @@ SmartSyncTestSuite.prototype.testFetchSObjects = function() {
             QUnit.deepEqual(_.values(idToName).sort(), _.pluck(result.records, "Name"), "Wrong names");
 
             console.log("## Cleaning up");
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2541,7 +2541,7 @@ SmartSyncTestSuite.prototype.testSObjectCollectionFetch = function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init(), cacheForOriginals.init());
+            return Promise.all(cache.init(), cacheForOriginals.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2632,7 +2632,7 @@ SmartSyncTestSuite.prototype.testSObjectCollectionFetch = function() {
             QUnit.deepEqual(_.values(idToName).sort(), _.pluck(result.records, "Name"), "Wrong names");
 
             console.log("## Cleaning up");
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
         })
         .then(function() {
             self.finalizeTest();
@@ -2659,7 +2659,7 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2670,7 +2670,7 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
             return self.trySyncDown(cache, soupName, idToName, cordova.require("com.salesforce.plugin.smartsync").MERGE_MODE.OVERWRITE);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2691,7 +2691,7 @@ SmartSyncTestSuite.prototype.testSyncDownToGlobalStore = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ], null /* default id */, true /* global */);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2703,12 +2703,12 @@ SmartSyncTestSuite.prototype.testSyncDownToGlobalStore = function() {
         })
         .then(function() {
             console.log("## Check both stores");
-            return $.when(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
+            return Promise.all(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
         })
         .then(function(exists, existsGlobal) {
             QUnit.equals(exists, false, "soup should not exist in regular store");
             QUnit.equals(existsGlobal, true, "soup should exist in global store");
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2732,7 +2732,7 @@ SmartSyncTestSuite.prototype.testSyncDownWithNoOverwrite = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2784,7 +2784,7 @@ SmartSyncTestSuite.prototype.testSyncDownWithNoOverwrite = function() {
                 QUnit.ok(record.Name.indexOf("Updated") == -1, "Record name should no longer have update");                
             });
 
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2806,7 +2806,7 @@ SmartSyncTestSuite.prototype.testRefreshSyncDown = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2832,7 +2832,7 @@ SmartSyncTestSuite.prototype.testRefreshSyncDown = function() {
             return self.trySyncDown(cache, soupName, idToName, cordova.require("com.salesforce.plugin.smartsync").MERGE_MODE.OVERWRITE, target);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2856,7 +2856,7 @@ SmartSyncTestSuite.prototype.testReSync = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2885,7 +2885,7 @@ SmartSyncTestSuite.prototype.testReSync = function() {
             return self.tryReSync(cache, soupName, idToName, syncDownId, _.keys(idToUpdatedName).length);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2911,7 +2911,7 @@ SmartSyncTestSuite.prototype.testCleanResyncGhosts = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() {
             console.log("## Direct creation against server");
@@ -2960,7 +2960,7 @@ SmartSyncTestSuite.prototype.testCleanResyncGhosts = function() {
             mustDelRecords[secondId] = idToName[secondId];
         })
         .then(function() {
-            return $.when(deleteRecords(mustDelRecords), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(mustDelRecords), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -2989,7 +2989,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3027,7 +3027,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
             return checkServerMultiple(updatedRecords);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3050,7 +3050,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ], null /* default id*/, true /* global */);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3074,7 +3074,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
         })
         .then(function() {
             console.log("## Check both stores");
-            return $.when(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
+            return Promise.all(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
         })
         .then(function(exists, existsGlobal) {
             QUnit.equals(exists, false, "soup should not exist in regular store");
@@ -3094,7 +3094,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
             return checkServerMultiple(updatedRecords);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3118,7 +3118,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithNoOverwrite = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3168,7 +3168,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithNoOverwrite = function(
         })
         .then(function(result) {
             QUnit.equals(result.records.length, 3, "Expected 3 records");
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3191,7 +3191,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3228,7 +3228,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
             QUnit.equals(resp.records.length, 0, "Expected 0 records");
 
             // Cleanup
-            return $.when(Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3252,7 +3252,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeletedWithNoOverwrite = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Direct creation against server");
@@ -3305,7 +3305,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeletedWithNoOverwrite = function(
             QUnit.equals(resp.records.length, 3, "Expected 3 records");
 
             // Cleanup
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3328,7 +3328,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyCreated = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return $.when(cache.init());
+            return Promise.all(cache.init());
         })
         .then(function() { 
             console.log("## Local creation");    
@@ -3363,7 +3363,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyCreated = function() {
             return checkServerMultiple(result.records);
         })
         .then(function() {
-            return $.when(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
         })
         .then(function() {
             self.finalizeTest();
@@ -3426,7 +3426,7 @@ var getCaller = function() {
  * Helper method to create several records on server
  */
 var createRecords = function(idToName, prefix, count) {
-    return $.when.apply(null, (_.map(_.range(count), function(i) {
+    return Promise.all.apply(null, (_.map(_.range(count), function(i) {
         var name = prefix + i;
         console.log("Creating " + name);
         return Force.forceJsClient.create("Account", {Name:name})
@@ -3441,7 +3441,7 @@ var createRecords = function(idToName, prefix, count) {
  * Helper method to update several records on server
  */
 var updateRecords = function(idToUpdatedName) {
-    return $.when.apply(null, (_.map(_.keys(idToUpdatedName), function(id) {
+    return Promise.all.apply(null, (_.map(_.keys(idToUpdatedName), function(id) {
         var updatedName = idToUpdatedName[id];
         console.log("Updating " + updatedName);
         return Force.forceJsClient.update("Account",{Id:id, Name:updatedName})
@@ -3455,7 +3455,7 @@ var updateRecords = function(idToUpdatedName) {
  * Helper method to delete several records on server
  */
 var deleteRecords = function(idToName) {
-    return $.when.apply(null, (_.map(_.keys(idToName), function(id) {
+    return Promise.all.apply(null, (_.map(_.keys(idToName), function(id) {
         var name = idToName[id];
         console.log("Deleting " + name);
         return Force.forceJsClient.del("account", id)
@@ -3520,7 +3520,7 @@ var rejectedPromiseWrapper = function(p) {
         .then(function(result) {
             d.resolve.apply(d, [{success:true, result:result}]);
         })
-        .fail(function(err) {
+        .catch(function(err) {
             d.resolve.apply(d, [{success:false, result:err}]);
         });
     return d.promise();
@@ -3534,7 +3534,7 @@ var checkCache = function(id, expectedCacheRecord, cache, caller) {
     if (cache == null) { 
         // no cache specified: expectedCacheRecord should be null
         assertContains(null, expectedCacheRecord, caller);
-        return $.when();
+        return Promise.all();
     }
     if (caller == null) caller = getCaller();
     console.log("## Direct retrieve from cache");
@@ -3553,7 +3553,7 @@ var checkServer = function(id, expectedServerRecord, caller) {
     if (id.indexOf("local_") == 0) { 
         // local id: server won't have record
         assertContains(null, expectedServerRecord, caller);
-        return $.when();
+        return Promise.all();
     }
     console.log("## Direct retrieve from server");
     var fields = expectedServerRecord == null ? "Id" : _.select(_.keys(expectedServerRecord), function(field) { return field.indexOf("__local") == -1; }).join(",");
@@ -3569,7 +3569,7 @@ var checkServer = function(id, expectedServerRecord, caller) {
  */
 var checkServerMultiple = function(records, caller) {
     if (caller == null) caller = getCaller();
-    return $.when.apply(null, _.map(records, function(record) {
+    return Promise.all.apply(null, _.map(records, function(record) {
         var expectedServerRecord = _.omit(record, "__local__", "__locally_created__", "__locally_deleted__", "__locally_updated__", "attributes", "_soupEntryId", "_soupLastModifiedDate");
         return checkServer(record.Id, expectedServerRecord, caller);
     }));
@@ -3583,7 +3583,7 @@ var checkResultServerAndCaches = function(data, expectedData, id, expectedServer
     if (caller == null) caller = getCaller();
     console.log("## Checking data returned by sync call");
     assertContains(data, expectedData, caller);
-    return $.when(checkServer(id, expectedServerRecord, caller), checkCache(id, expectedCacheRecord, cache, caller), checkCache(id, expectedCacheRecord2, cache2, caller));
+    return Promise.all(checkServer(id, expectedServerRecord, caller), checkCache(id, expectedCacheRecord, cache, caller), checkCache(id, expectedCacheRecord2, cache2, caller));
 };
 
 /** 
@@ -3617,7 +3617,7 @@ var tryConflictDetection = function(message, cache, cacheForOriginals, theirs, y
         if (expectedResult.success) return checkResultServerAndCaches(result.result, newTheirs, id, newTheirs, newYours, cache, newBase, cacheForOriginals, caller);
     })
     .then(function() {
-        if (cleanup) return $.when(Force.forceJsClient.del("account", id));
+        if (cleanup) return Promise.all(Force.forceJsClient.del("account", id));
     });
 };
 

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -42,6 +42,7 @@ SmartSyncTestSuite.prototype = new SFTestSuite();
 SmartSyncTestSuite.prototype.constructor = SmartSyncTestSuite;
 
 // SmartSyncPlugin
+var promiser = cordova.require("com.salesforce.util.promiser").promiser;
 SmartSyncTestSuite.prototype.cleanResyncGhosts = promiser(cordova.require("com.salesforce.plugin.smartsync"), "cleanResyncGhosts");
 SmartSyncTestSuite.prototype.reSync = promiser(cordova.require("com.salesforce.plugin.smartsync"), "reSync");
 SmartSyncTestSuite.prototype.syncDown = promiser(cordova.require("com.salesforce.plugin.smartsync"), "syncDown");

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -34,7 +34,7 @@ var SmartSyncTestSuite = function () {
     SFTestSuite.call(this, "SmartSyncTestSuite");
 
     // To run specific tests
-    // this.testsToRun = ["testSyncUpLocallyUpdatedWithGlobalStore"];
+    this.testsToRun = ["testSObjectTypeDescribe"];
 };
 
 // We are sub-classing SFTestSuite
@@ -480,13 +480,13 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
     var querySpec007 = {queryType:"exact", indexPath:"Name", matchKey:"JamesBond", order:"ascending", pageSize:1}
     var querySpec008 = {queryType:"exact", indexPath:"Name", matchKey:"Vilain", order:"ascending", pageSize:1}
 
-    Promise.all(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
-           Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName))
+    Promise.all([Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
+                 Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName)])
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, indexSpecs, null, REGULAR_STORE);
             cacheGlobal = new Force.StoreCache(soupName, indexSpecs, null, GLOBAL_STORE);
-            return Promise.all(cache.init(), cacheGlobal.init());
+            return Promise.all([cache.init(), cacheGlobal.init()]);
         })
         .then(function() {
             console.log("## Save record into regular cache");
@@ -494,9 +494,10 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
         })
         .then(function() {
             console.log("## Looking for record in both caches");
-            return Promise.all(cache.find(querySpec007), cacheGlobal.find(querySpec007));
+            return Promise.all([cache.find(querySpec007), cacheGlobal.find(querySpec007)]);
         })
-        .then(function(result, resultGlobal) {
+        .then(function(results) {
+            var result = results[0], resultGlobal = results[1];
             console.log("## Checking result from regular cache");
             QUnit.equals(result.records.length, 1);
             assertContains(result.records[0], agent007);
@@ -507,9 +508,10 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
         })
         .then(function() {
             console.log("## Looking for record in both caches");
-            return Promise.all(cache.find(querySpec008), cacheGlobal.find(querySpec008));
+            return Promise.all([cache.find(querySpec008), cacheGlobal.find(querySpec008)]);
         })
-        .then(function(result, resultGlobal) {
+        .then(function(results) {
+            var result = results[0], resultGlobal = results[1];
             console.log("## Checking result from regular cache");
             QUnit.equals(result.records.length, 0);
             console.log("## Checking result from global cache");
@@ -518,8 +520,8 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
             console.log("## Save record into global cache");
 
             // Cleaning up 
-            return Promise.all(Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
-                          Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName))
+            return Promise.all([Force.smartstoreClient.removeSoup(REGULAR_STORE, soupName),
+                                Force.smartstoreClient.removeSoup(GLOBAL_STORE, soupName)])
         })
         .then(function() {
             self.finalizeTest();
@@ -673,9 +675,10 @@ SmartSyncTestSuite.prototype.testSObjectTypeCacheOnlyMode = function() {
     .then(function() {
         console.log("## Calling describe layout");
         var sobjectType = new Force.SObjectType("MockObject", cache, Force.CACHE_MODE.CACHE_ONLY);
-        return Promise.all(sobjectType.describe(), sobjectType.getMetadata(), sobjectType.describeLayout());
+        return Promise.all([sobjectType.describe(), sobjectType.getMetadata(), sobjectType.describeLayout()]);
     })
-    .then(function(descResult, metaResult, layoutResult) {
+    .then(function(results) {
+        var descResult = results[0], metadataResult = results[1], layoutResult = results[2];
         assertContains(descResult, data.describeResult);
         assertContains(metaResult, data.metadataResult);
         assertContains(layoutResult, data.layoutInfo_012000000000000AAA);
@@ -749,17 +752,19 @@ SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
         console.log("## Calling describe layout");
         var accountType = new Force.SObjectType("Account", cache);
         var contactType = new Force.SObjectType("Contact", cache);
-        return Promise.all(accountType.describe(), contactType.describe());
+        return Promise.all([accountType.describe(), contactType.describe()]);
     })
-    .then(function(data1, data2) {
+    .then(function(results) {
+        var data1 = results[0], data2 = results[1];
         accountDescribe = data1;
         contactDescribe = data2;
         QUnit.equals('Account', accountDescribe.name, 'Describe result should be for Account');
         QUnit.equals('Contact', contactDescribe.name, 'Describe result should be for Contact');
         console.log("## Checking underlying cache");
-        return Promise.all(cache.retrieve("Account"), cache.retrieve("Contact"));
+        return Promise.all([cache.retrieve("Account"), cache.retrieve("Contact")]);
     })
-    .then(function(accountCache, contactCache) {    
+    .then(function(results) {
+        var accountCache = results[0], contactCache = results[1];
         assertContains(accountDescribe, accountCache.describeResult);
         assertContains(contactDescribe, contactCache.describeResult);
         console.log("## Cleaning up");
@@ -789,7 +794,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeReset = function() {
     .then(function() { 
         console.log("## Calling getMetadata and describe");
         sobjectType = new Force.SObjectType("Account", cache);
-        return Promise.all(sobjectType.getMetadata(), sobjectType.describe());
+        return Promise.all([sobjectType.getMetadata(), sobjectType.describe()]);
     })
     .then(function() {
         console.log("## Checking underlying cache");
@@ -1302,7 +1307,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectCreate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -1385,7 +1390,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectRetrieve = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -1442,7 +1447,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectUpdate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -1502,7 +1507,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDelete = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.smartstoreClient.removeSoup(soupName));
+            return Force.smartstoreClient.removeSoup(soupName);
         })
         .then(function() {
             self.finalizeTest();
@@ -1527,12 +1532,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictCreate = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Trying create server-only");
@@ -1560,8 +1565,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictCreate = function() {
         })
         .then(function(data) {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals),
-                          Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.forceJsClient.del("account", id),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals),
+                                Force.forceJsClient.del("account", id2),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
 
         })
         .then(function() {
@@ -1581,12 +1590,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -1646,7 +1655,10 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.forceJsClient.del("account", id2), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.forceJsClient.del("account", id),
+                                Force.forceJsClient.del("account", id2),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -1664,12 +1676,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -1823,7 +1835,9 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.forceJsClient.del("account", id),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -1841,12 +1855,12 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
     var soupNameForOriginals = "originalsFor" + soupName;
     var id, id2;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
             cache = new Force.StoreCache(soupName);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -2005,7 +2019,8 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2033,10 +2048,10 @@ SmartSyncTestSuite.prototype.testSObjectFetch = function() {
     var accountFetch = optionsPromiser(account, "fetch", "account");
     var id;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Direct creation against server");    
@@ -2054,7 +2069,9 @@ SmartSyncTestSuite.prototype.testSObjectFetch = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.forceJsClient.del("account", id),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2077,10 +2094,10 @@ SmartSyncTestSuite.prototype.testSObjectSave = function() {
     var accountSave = optionsPromiser(account, "save", "account");
     var id;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Trying save with default cacheMode and mergeMode");
@@ -2094,7 +2111,9 @@ SmartSyncTestSuite.prototype.testSObjectSave = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.forceJsClient.del("account", id), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.forceJsClient.del("account", id),
+                                Force.smartstoreClient.removeSoup(soupName),
+                                Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2117,10 +2136,10 @@ SmartSyncTestSuite.prototype.testSObjectDestroy = function() {
     var accountDestroy = optionsPromiser(account, "destroy", "account");
     var id;
 
-    Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals))
+    Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)])
         .then(function() {
             console.log("## Initialization of StoreCaches");
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() {
             console.log("## Trying destroy with default cacheMode and mergeMode");
@@ -2140,7 +2159,7 @@ SmartSyncTestSuite.prototype.testSObjectDestroy = function() {
         })
         .then(function() {
             console.log("## Cleaning up");
-            return Promise.all(Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2430,7 +2449,7 @@ SmartSyncTestSuite.prototype.testFetchSObjects = function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2512,7 +2531,7 @@ SmartSyncTestSuite.prototype.testFetchSObjects = function() {
             QUnit.deepEqual(_.values(idToName).sort(), _.pluck(result.records, "Name"), "Wrong names");
 
             console.log("## Cleaning up");
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2541,7 +2560,7 @@ SmartSyncTestSuite.prototype.testSObjectCollectionFetch = function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
             cacheForOriginals = new Force.StoreCache(soupNameForOriginals, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init(), cacheForOriginals.init());
+            return Promise.all([cache.init(), cacheForOriginals.init()]);
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2632,7 +2651,7 @@ SmartSyncTestSuite.prototype.testSObjectCollectionFetch = function() {
             QUnit.deepEqual(_.values(idToName).sort(), _.pluck(result.records, "Name"), "Wrong names");
 
             console.log("## Cleaning up");
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName), Force.smartstoreClient.removeSoup(soupNameForOriginals)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2659,7 +2678,7 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2670,7 +2689,7 @@ SmartSyncTestSuite.prototype.testSyncDown = function() {
             return self.trySyncDown(cache, soupName, idToName, cordova.require("com.salesforce.plugin.smartsync").MERGE_MODE.OVERWRITE);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2691,7 +2710,7 @@ SmartSyncTestSuite.prototype.testSyncDownToGlobalStore = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ], null /* default id */, true /* global */);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2703,12 +2722,12 @@ SmartSyncTestSuite.prototype.testSyncDownToGlobalStore = function() {
         })
         .then(function() {
             console.log("## Check both stores");
-            return Promise.all(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
+            return Promise.all([Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName)]);
         })
         .then(function(exists, existsGlobal) {
             QUnit.equals(exists, false, "soup should not exist in regular store");
             QUnit.equals(existsGlobal, true, "soup should exist in global store");
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2732,7 +2751,7 @@ SmartSyncTestSuite.prototype.testSyncDownWithNoOverwrite = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2784,7 +2803,7 @@ SmartSyncTestSuite.prototype.testSyncDownWithNoOverwrite = function() {
                 QUnit.ok(record.Name.indexOf("Updated") == -1, "Record name should no longer have update");                
             });
 
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2806,7 +2825,7 @@ SmartSyncTestSuite.prototype.testRefreshSyncDown = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2832,7 +2851,7 @@ SmartSyncTestSuite.prototype.testRefreshSyncDown = function() {
             return self.trySyncDown(cache, soupName, idToName, cordova.require("com.salesforce.plugin.smartsync").MERGE_MODE.OVERWRITE, target);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2856,7 +2875,7 @@ SmartSyncTestSuite.prototype.testReSync = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -2885,7 +2904,7 @@ SmartSyncTestSuite.prototype.testReSync = function() {
             return self.tryReSync(cache, soupName, idToName, syncDownId, _.keys(idToUpdatedName).length);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2911,7 +2930,7 @@ SmartSyncTestSuite.prototype.testCleanResyncGhosts = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() {
             console.log("## Direct creation against server");
@@ -2960,7 +2979,7 @@ SmartSyncTestSuite.prototype.testCleanResyncGhosts = function() {
             mustDelRecords[secondId] = idToName[secondId];
         })
         .then(function() {
-            return Promise.all(deleteRecords(mustDelRecords), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(mustDelRecords), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -2989,7 +3008,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3027,7 +3046,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdated = function() {
             return checkServerMultiple(updatedRecords);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -3050,7 +3069,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ], null /* default id*/, true /* global */);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3074,7 +3093,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
         })
         .then(function() {
             console.log("## Check both stores");
-            return Promise.all(Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName));
+            return Promise.all([Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName)]);
         })
         .then(function(exists, existsGlobal) {
             QUnit.equals(exists, false, "soup should not exist in regular store");
@@ -3094,7 +3113,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
             return checkServerMultiple(updatedRecords);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -3118,7 +3137,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithNoOverwrite = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3168,7 +3187,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithNoOverwrite = function(
         })
         .then(function(result) {
             QUnit.equals(result.records.length, 3, "Expected 3 records");
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -3191,7 +3210,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");    
@@ -3228,7 +3247,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeleted = function() {
             QUnit.equals(resp.records.length, 0, "Expected 0 records");
 
             // Cleanup
-            return Promise.all(Force.smartstoreClient.removeSoup(soupName));
+            return Force.smartstoreClient.removeSoup(soupName);
         })
         .then(function() {
             self.finalizeTest();
@@ -3252,7 +3271,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeletedWithNoOverwrite = function(
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Direct creation against server");
@@ -3305,7 +3324,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyDeletedWithNoOverwrite = function(
             QUnit.equals(resp.records.length, 3, "Expected 3 records");
 
             // Cleanup
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -3328,7 +3347,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyCreated = function() {
         .then(function() {
             console.log("## Initialization of StoreCache's");
             cache = new Force.StoreCache(soupName, [ {path:"Name", type:"string"} ]);
-            return Promise.all(cache.init());
+            return cache.init();
         })
         .then(function() { 
             console.log("## Local creation");    
@@ -3363,7 +3382,7 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyCreated = function() {
             return checkServerMultiple(result.records);
         })
         .then(function() {
-            return Promise.all(deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName));
+            return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(soupName)]);
         })
         .then(function() {
             self.finalizeTest();
@@ -3426,7 +3445,7 @@ var getCaller = function() {
  * Helper method to create several records on server
  */
 var createRecords = function(idToName, prefix, count) {
-    return Promise.all.apply(null, (_.map(_.range(count), function(i) {
+    return Promise.all(_.map(_.range(count), function(i) {
         var name = prefix + i;
         console.log("Creating " + name);
         return Force.forceJsClient.create("Account", {Name:name})
@@ -3434,78 +3453,78 @@ var createRecords = function(idToName, prefix, count) {
                 console.log("Created" + name);
                 idToName[resp.id] = name;
             });
-    })));
+    }));
 };
 
 /**
  * Helper method to update several records on server
  */
 var updateRecords = function(idToUpdatedName) {
-    return Promise.all.apply(null, (_.map(_.keys(idToUpdatedName), function(id) {
+    return Promise.all(_.map(_.keys(idToUpdatedName), function(id) {
         var updatedName = idToUpdatedName[id];
         console.log("Updating " + updatedName);
         return Force.forceJsClient.update("Account",{Id:id, Name:updatedName})
             .then(function(resp) {
                 console.log("Updated " + updatedName);
             });
-    })));
+    }));
 };
 
 /**
  * Helper method to delete several records on server
  */
 var deleteRecords = function(idToName) {
-    return Promise.all.apply(null, (_.map(_.keys(idToName), function(id) {
+    return Promise.all(_.map(_.keys(idToName), function(id) {
         var name = idToName[id];
         console.log("Deleting " + name);
         return Force.forceJsClient.del("account", id)
                     .then(function() {
                         console.log("Deleted " + name);
                     });
-    })));
+    }));
 };
 
 /**
  * Helper function turning event listener into promise
  */
 var eventPromiser = function(object, eventName, filter) {
-    var d = $.Deferred();
-    var listener = function(e) {
-        if (filter(e)) {
-            d.resolve(e);
-            object.removeEventListener(eventName, listener);
+    return new Promise(function(resolve, reject) {
+        var listener = function(e) {
+            if (filter(e)) {
+                resolve(e);
+                object.removeEventListener(eventName, listener);
+            }
         }
-    }
-    object.addEventListener(eventName, listener, false);
-    return d.promise();
+        object.addEventListener(eventName, listener, false);
+    });
 };
 
 /**
  * Helper function turning setTimeout into promise
  */
 var timeoutPromiser = function(millis) {
-    var d = $.Deferred();
-    setTimeout(function() {
-        d.resolve();
-    }, millis);
-    return d.promise();
+    return new Promise(function(resolve, reject) {
+        setTimeout(function() {
+            resolve();
+        }, millis);
+    });
 };
-
 
 /**
  * Helper function turning function taking success/error options into promise
  */
 var optionsPromiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = $.makeArray(arguments);
-        var d = $.Deferred();
-        if (args.length == 0 || !_.isObject(_.last(args))) { args.push({}); }
-        var options = _.last(args);
-        options.success = function() {d.resolve.apply(d, arguments);};
-        options.error = function() {d.reject.apply(d, arguments);};
-        console.log("-----> Calling " + objectName + ":" + methodName);
-        object[methodName].apply(object, args);
-        return d.promise();
+        var args = Array.from(arguments);
+
+        return new Promise(function(resolve, reject) {
+            if (args.length == 0 || !_.isObject(_.last(args))) { args.push({}); }
+            var options = _.last(args);
+            options.success = function() {resolve.apply(null, arguments);};
+            options.error = function() {reject.apply(null, arguments);};
+            console.log("-----> Calling " + objectName + ":" + methodName);
+            object[methodName].apply(object, args);
+        });
     };
     return retfn;
 };
@@ -3515,15 +3534,15 @@ var optionsPromiser = function(object, methodName, objectName) {
  * {success:true, result:<wrapped promise result>} or {success:false, result:<wrapper promise fail result>}
  */
 var rejectedPromiseWrapper = function(p) {
-    var d = $.Deferred();
-    p
-        .then(function(result) {
-            d.resolve.apply(d, [{success:true, result:result}]);
-        })
-        .catch(function(err) {
-            d.resolve.apply(d, [{success:false, result:err}]);
-        });
-    return d.promise();
+    return new Promise(function(resolve, reject) {
+        p
+            .then(function(result) {
+                resolve([{success:true, result:result}]);
+            })
+            .catch(function(err) {
+                resolve([{success: false, result:err}]);
+            });
+    });
 };
 
 
@@ -3534,7 +3553,7 @@ var checkCache = function(id, expectedCacheRecord, cache, caller) {
     if (cache == null) { 
         // no cache specified: expectedCacheRecord should be null
         assertContains(null, expectedCacheRecord, caller);
-        return Promise.all();
+        return Promise.resolve();
     }
     if (caller == null) caller = getCaller();
     console.log("## Direct retrieve from cache");
@@ -3553,7 +3572,7 @@ var checkServer = function(id, expectedServerRecord, caller) {
     if (id.indexOf("local_") == 0) { 
         // local id: server won't have record
         assertContains(null, expectedServerRecord, caller);
-        return Promise.all();
+        return Promise.resolve();
     }
     console.log("## Direct retrieve from server");
     var fields = expectedServerRecord == null ? "Id" : _.select(_.keys(expectedServerRecord), function(field) { return field.indexOf("__local") == -1; }).join(",");
@@ -3569,7 +3588,7 @@ var checkServer = function(id, expectedServerRecord, caller) {
  */
 var checkServerMultiple = function(records, caller) {
     if (caller == null) caller = getCaller();
-    return Promise.all.apply(null, _.map(records, function(record) {
+    return Promise.all(_.map(records, function(record) {
         var expectedServerRecord = _.omit(record, "__local__", "__locally_created__", "__locally_deleted__", "__locally_updated__", "attributes", "_soupEntryId", "_soupLastModifiedDate");
         return checkServer(record.Id, expectedServerRecord, caller);
     }));
@@ -3583,7 +3602,7 @@ var checkResultServerAndCaches = function(data, expectedData, id, expectedServer
     if (caller == null) caller = getCaller();
     console.log("## Checking data returned by sync call");
     assertContains(data, expectedData, caller);
-    return Promise.all(checkServer(id, expectedServerRecord, caller), checkCache(id, expectedCacheRecord, cache, caller), checkCache(id, expectedCacheRecord2, cache2, caller));
+    return Promise.all([checkServer(id, expectedServerRecord, caller), checkCache(id, expectedCacheRecord, cache, caller), checkCache(id, expectedCacheRecord2, cache2, caller)]);
 };
 
 /** 
@@ -3617,7 +3636,7 @@ var tryConflictDetection = function(message, cache, cacheForOriginals, theirs, y
         if (expectedResult.success) return checkResultServerAndCaches(result.result, newTheirs, id, newTheirs, newYours, cache, newBase, cacheForOriginals, caller);
     })
     .then(function() {
-        if (cleanup) return Promise.all(Force.forceJsClient.del("account", id));
+        if (cleanup) return Force.forceJsClient.del("account", id);
     });
 };
 

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -3518,7 +3518,8 @@ var timeoutPromiser = function(millis) {
  */
 var optionsPromiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = Array.from(arguments);
+        var args = [];
+        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
 
         return new Promise(function(resolve, reject) {
             if (args.length == 0 || !_.isObject(_.last(args))) { args.push({}); }

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -3518,8 +3518,7 @@ var timeoutPromiser = function(millis) {
  */
 var optionsPromiser = function(object, methodName, objectName) {
     var retfn = function () {
-        var args = [];
-        for (var i=0; i<arguments.length; i++) { args.push(arguments[i]); }
+        var args = Array.prototype.slice.call(arguments);
 
         return new Promise(function(resolve, reject) {
             if (args.length == 0 || !_.isObject(_.last(args))) { args.push({}); }

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -34,7 +34,7 @@ var SmartSyncTestSuite = function () {
     SFTestSuite.call(this, "SmartSyncTestSuite");
 
     // To run specific tests
-    // this.testsToRun = ["testSObjectTypeDescribe"];
+    // this.testsToRun = ["testSyncSObjectDetectConflictDelete"];
 };
 
 // We are sub-classing SFTestSuite
@@ -1668,7 +1668,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
 /** 
  * TEST Force.syncSObjectDetectConflict for method update
  */
-SmartSyncTestSuite.prototype._testSyncSObjectDetectConflictUpdate = function() {
+SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
     console.log("# In SmartSyncTestSuite.testSyncSObjectDetectConflictUpdate");
     var self = this;
     var cache, cacheForOriginals;
@@ -1847,7 +1847,7 @@ SmartSyncTestSuite.prototype._testSyncSObjectDetectConflictUpdate = function() {
 /** 
  * TEST Force.syncSObjectDetectConflict for method delete
  */
-SmartSyncTestSuite.prototype._testSyncSObjectDetectConflictDelete = function() {
+SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
     console.log("# In SmartSyncTestSuite.testSyncSObjectDetectConflictDelete");
     var self = this;
     var cache, cacheForOriginals;
@@ -3539,10 +3539,10 @@ var rejectedPromiseWrapper = function(p) {
     return new Promise(function(resolve, reject) {
         p
             .then(function(result) {
-                resolve([{success:true, result:result}]);
+                resolve({success:true, result:result});
             })
             .catch(function(err) {
-                resolve([{success: false, result:err}]);
+                resolve({success: false, result:err});
             });
     });
 };

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -34,7 +34,7 @@ var SmartSyncTestSuite = function () {
     SFTestSuite.call(this, "SmartSyncTestSuite");
 
     // To run specific tests
-    this.testsToRun = ["testSObjectTypeDescribe"];
+    // this.testsToRun = ["testSObjectTypeDescribe"];
 };
 
 // We are sub-classing SFTestSuite
@@ -537,7 +537,7 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
 /** 
  * TEST Force.SObjectType.describe
  */
-SmartSyncTestSuite.prototype.testSObjectTypeDescribe = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeDescribe = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeDescribe");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -576,7 +576,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeDescribe = function() {
 /** 
  * TEST Force.SObjectType.getMetadata
  */
-SmartSyncTestSuite.prototype.testSObjectTypeGetMetadata = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeGetMetadata = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeGetMetadata");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -615,7 +615,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeGetMetadata = function() {
 /** 
  * TEST Force.SObjectType.describeLayout
  */
-SmartSyncTestSuite.prototype.testSObjectTypeDescribeLayout = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeDescribeLayout = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeDescribeLayout");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -652,7 +652,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeDescribeLayout = function() {
 /**
  * TEST Force.SObjectType cache merge by multiple instances
  */
-SmartSyncTestSuite.prototype.testSObjectTypeCacheOnlyMode = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeCacheOnlyMode = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeCacheOnlyMode");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -693,7 +693,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeCacheOnlyMode = function() {
 /** 
  * TEST Force.SObjectType cache merge by multiple instances
  */
-SmartSyncTestSuite.prototype.testSObjectTypeCacheMerge = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeCacheMerge = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeCacheMerge");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -736,7 +736,7 @@ SmartSyncTestSuite.prototype.testSObjectTypeCacheMerge = function() {
 /** 
  * TEST Force.SObjectType multiple types
  */
-SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
+SmartSyncTestSuite.prototype._testMultiSObjectTypes = function() {
     console.log("# In SmartSyncTestSuite.testMultiSObjectTypes");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -778,7 +778,7 @@ SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
 /** 
  * TEST Force.SObjectType.reset
  */
-SmartSyncTestSuite.prototype.testSObjectTypeReset = function() {
+SmartSyncTestSuite.prototype._testSObjectTypeReset = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeReset");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -1668,7 +1668,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictRetrieve = function() 
 /** 
  * TEST Force.syncSObjectDetectConflict for method update
  */
-SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
+SmartSyncTestSuite.prototype._testSyncSObjectDetectConflictUpdate = function() {
     console.log("# In SmartSyncTestSuite.testSyncSObjectDetectConflictUpdate");
     var self = this;
     var cache, cacheForOriginals;
@@ -1847,7 +1847,7 @@ SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictUpdate = function() {
 /** 
  * TEST Force.syncSObjectDetectConflict for method delete
  */
-SmartSyncTestSuite.prototype.testSyncSObjectDetectConflictDelete = function() {
+SmartSyncTestSuite.prototype._testSyncSObjectDetectConflictDelete = function() {
     console.log("# In SmartSyncTestSuite.testSyncSObjectDetectConflictDelete");
     var self = this;
     var cache, cacheForOriginals;
@@ -2724,7 +2724,8 @@ SmartSyncTestSuite.prototype.testSyncDownToGlobalStore = function() {
             console.log("## Check both stores");
             return Promise.all([Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName)]);
         })
-        .then(function(exists, existsGlobal) {
+        .then(function(results) {
+            var exists = results[0], existsGlobal = results[1];
             QUnit.equals(exists, false, "soup should not exist in regular store");
             QUnit.equals(existsGlobal, true, "soup should exist in global store");
             return Promise.all([deleteRecords(idToName), Force.smartstoreClient.removeSoup(true /* global */, soupName)]);
@@ -3095,7 +3096,8 @@ SmartSyncTestSuite.prototype.testSyncUpLocallyUpdatedWithGlobalStore = function(
             console.log("## Check both stores");
             return Promise.all([Force.smartstoreClient.soupExists(false, soupName), Force.smartstoreClient.soupExists(true, soupName)]);
         })
-        .then(function(exists, existsGlobal) {
+        .then(function(results) {
+            var exists = results[0], existsGlobal = results[1];
             QUnit.equals(exists, false, "soup should not exist in regular store");
             QUnit.equals(existsGlobal, true, "soup should exist in global store");
             console.log("## Checking cache");

--- a/test/SFSmartSyncTestSuite.js
+++ b/test/SFSmartSyncTestSuite.js
@@ -537,7 +537,7 @@ SmartSyncTestSuite.prototype.testStoreCacheWithGlobalStore = function() {
 /** 
  * TEST Force.SObjectType.describe
  */
-SmartSyncTestSuite.prototype._testSObjectTypeDescribe = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeDescribe = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeDescribe");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -576,7 +576,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeDescribe = function() {
 /** 
  * TEST Force.SObjectType.getMetadata
  */
-SmartSyncTestSuite.prototype._testSObjectTypeGetMetadata = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeGetMetadata = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeGetMetadata");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -615,7 +615,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeGetMetadata = function() {
 /** 
  * TEST Force.SObjectType.describeLayout
  */
-SmartSyncTestSuite.prototype._testSObjectTypeDescribeLayout = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeDescribeLayout = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeDescribeLayout");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -652,7 +652,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeDescribeLayout = function() {
 /**
  * TEST Force.SObjectType cache merge by multiple instances
  */
-SmartSyncTestSuite.prototype._testSObjectTypeCacheOnlyMode = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeCacheOnlyMode = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeCacheOnlyMode");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -680,7 +680,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeCacheOnlyMode = function() {
     .then(function(results) {
         var descResult = results[0], metadataResult = results[1], layoutResult = results[2];
         assertContains(descResult, data.describeResult);
-        assertContains(metaResult, data.metadataResult);
+        assertContains(metadataResult, data.metadataResult);
         assertContains(layoutResult, data.layoutInfo_012000000000000AAA);
         console.log("## Cleaning up");
         return Force.smartstoreClient.removeSoup(soupName);
@@ -693,7 +693,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeCacheOnlyMode = function() {
 /** 
  * TEST Force.SObjectType cache merge by multiple instances
  */
-SmartSyncTestSuite.prototype._testSObjectTypeCacheMerge = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeCacheMerge = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeCacheMerge");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -736,7 +736,7 @@ SmartSyncTestSuite.prototype._testSObjectTypeCacheMerge = function() {
 /** 
  * TEST Force.SObjectType multiple types
  */
-SmartSyncTestSuite.prototype._testMultiSObjectTypes = function() {
+SmartSyncTestSuite.prototype.testMultiSObjectTypes = function() {
     console.log("# In SmartSyncTestSuite.testMultiSObjectTypes");
     var self = this;
     var soupName = "testSoupForSObjectType";
@@ -778,7 +778,7 @@ SmartSyncTestSuite.prototype._testMultiSObjectTypes = function() {
 /** 
  * TEST Force.SObjectType.reset
  */
-SmartSyncTestSuite.prototype._testSObjectTypeReset = function() {
+SmartSyncTestSuite.prototype.testSObjectTypeReset = function() {
     console.log("# In SmartSyncTestSuite.testSObjectTypeReset");
     var self = this;
     var soupName = "testSoupForSObjectType";

--- a/test/SFTestSuite.js
+++ b/test/SFTestSuite.js
@@ -31,27 +31,27 @@
  */
 if (typeof promiser === 'undefined') {
 
-var promiser = function(object, methodName, noAssertionOnFailure) {
-    var retfn = function () {
-        console.log("In " + methodName);
-        var self = this;
-        var args = $.makeArray(arguments);
-        var d = $.Deferred();
-        args.push(function() {
-            console.log(methodName + " succeeded");
-            d.resolve.apply(d, arguments);
-        });
-        args.push(function() {
-            console.log(methodName + " failed");
-            //console.log("Failure-->" + JSON.stringify($.makeArray(arguments)));
-            if (!noAssertionOnFailure) self.setAssertionFailed(methodName + " failed");
-            d.reject.apply(d, arguments);
-        });
-        object[methodName].apply(object, args);
-        return d.promise();
-    };
-    return retfn;
-}
+    var promiser = function(object, methodName, noAssertionOnFailure) {
+        var retfn = function () {
+            console.log("In " + methodName);
+            var self = this;
+            var args = Array.from(arguments);
+            return new Promise(function(resolve, reject) {
+                args.push(function() {
+                    console.log(methodName + " succeeded");
+                    resolve.apply(null, arguments);
+                });
+                args.push(function() {
+                    console.log(methodName + " failed");
+                    //console.log("Failure-->" + JSON.stringify(Array.from(arguments)));
+                    if (!noAssertionOnFailure) self.setAssertionFailed(methodName + " failed");
+                    reject.apply(null, Array.from(arguments));
+                });
+                object[methodName].apply(object, args);
+            });
+        };
+        return retfn;
+    }
 
 };
 

--- a/test/SFTestSuite.js
+++ b/test/SFTestSuite.js
@@ -24,37 +24,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-/**
- * Build a function returning a promise from a function that takes a success and error callback as last arguments
- * The new function will take the same arguments as the original function minus the two callback functions
- */
-if (typeof promiser === 'undefined') {
-
-    var promiser = function(object, methodName, noAssertionOnFailure) {
-        var retfn = function () {
-            console.log("In " + methodName);
-            var self = this;
-            var args = Array.from(arguments);
-            return new Promise(function(resolve, reject) {
-                args.push(function() {
-                    console.log(methodName + " succeeded");
-                    resolve.apply(null, arguments);
-                });
-                args.push(function() {
-                    console.log(methodName + " failed");
-                    //console.log("Failure-->" + JSON.stringify(Array.from(arguments)));
-                    if (!noAssertionOnFailure) self.setAssertionFailed(methodName + " failed");
-                    reject.apply(null, Array.from(arguments));
-                });
-                object[methodName].apply(object, args);
-            });
-        };
-        return retfn;
-    }
-
-};
-
 /**
  * SFTestStatus - Represents a particular test and its status information.
  */

--- a/test/forcepluginstest/index.html
+++ b/test/forcepluginstest/index.html
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 
     <!-- external libs -->
-    <script src="dependencies/jquery/jquery.min.js"></script>
     <script src="dependencies/underscore/underscore-min.js"></script>
     <script src="dependencies/backbone/backbone-min.js"></script>
 

--- a/test/test.html
+++ b/test/test.html
@@ -4,7 +4,6 @@
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
 
     <!-- external libs -->
-    <script src="dependencies/jquery/jquery.min.js"></script>
     <script src="dependencies/underscore/underscore-min.js"></script>
     <script src="dependencies/backbone/backbone-min.js"></script>
 


### PR DESCRIPTION
* smartsync.js no longer depends on jquery - instead it uses native promises 
* tests no longer use jquery
* userlist sample app no longer uses jquery however sample apps that use Backbone.View still need jquery

* there is now a smartstoreClient (navigator.smartstoreClient or cordova.require("com.salesforce.plugin.smartstore.client") which offers promise-based versions of smartstore methods. (Previously we had such an object in smartsync.js, and we were using it in tests).
* there is now a forceJsClient (defined in force.js) which offers promise-based versions of force's async methods. (Previously we had such an object in smartsync.js, and we were using it in tests).

* NB: Native promises are supported on iOS and on Android 20 (4.4.4) and above.
Currently, our min Android version is 19 (4.4) - so we should either move it up to 20 or document the need for the promise polyfill on Android 19.


