### PR TITLE
test_force fails to create ios native apps

### DIFF
--- a/node/test_force.js
+++ b/node/test_force.js
@@ -77,6 +77,7 @@ function main(args) {
         var repoDir = cloneRepo(tmpDir, fork, repoName, branch);
         runProcessThrowError('sh install.sh', repoDir);
         createDeployForcePackage(repoDir, tmpDir, OS.ios, version);
+        editCreateAppToNotDoPodInstall(tmpDir);
     }
 
     // Get android repo if requested
@@ -284,6 +285,16 @@ function editForceScriptToUseLocalPluginRepo(tmpDir, os) {
     log('Editing  ' + forcePackageNameForOs(os) + '.js to use local cordova plugin', COLOR.green);
     miscUtils.replaceTextInFile(path.join(tmpDir, 'node_modules', forcePackageNameForOs(os), 'node', forcePackageNameForOs(os) + '.js'), new RegExp('\'cordova plugin add .*\'', 'g'), '\'cordova plugin add ../SalesforceMobileSDK-CordovaPlugin\'');
 }
+
+//
+// Update createApp.sh to not do pod install
+// 
+function editCreateAppToNotDoPodInstall(tmpDir) {
+    log('Editing  createApp.sh to not do pod install', COLOR.green);
+    miscUtils.replaceTextInFile(path.join(tmpDir, 'node_modules', 'forceios', 'build', 'app_template_files', 'createApp.sh'), new RegExp('pod install$', 'g'), '# pod install');
+
+}
+
 
 //
 // Update podfile to use local ios repo

--- a/node/test_force.js
+++ b/node/test_force.js
@@ -291,7 +291,7 @@ function editForceScriptToUseLocalPluginRepo(tmpDir, os) {
 // 
 function editCreateAppToNotDoPodInstall(tmpDir) {
     log('Editing  createApp.sh to not do pod install', COLOR.green);
-    miscUtils.replaceTextInFile(path.join(tmpDir, 'node_modules', 'forceios', 'build', 'app_template_files', 'createApp.sh'), new RegExp('pod install$', 'g'), '# pod install');
+    miscUtils.replaceTextInFile(path.join(tmpDir, 'node_modules', 'forceios', 'build', 'app_template_files', 'createApp.sh'), new RegExp('^\\s*pod install', 'g'), '# pod install');
 
 }
 


### PR DESCRIPTION
test_force.js invokes forceios which internally does a pod install (which goes against the published pod specs).
Then test_force.js edit the pod file of the generated application to point to local copies of the Mobile SDK and then does a pod update.
That doesn't work now because the SalesforceAnalytics pod exists in development but not in production.

The solution is to have test_force.js disable the pod install call in forceios (actually it lives in createApp.sh) before executing forceios.