### PR TITLE
Changes to reflect the fact that getAuthCredentials does not trigger …

### DIFF
--- a/gen/plugins/com.salesforce/com.salesforce.plugin.oauth.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.oauth.js
@@ -37,9 +37,7 @@ var exec = require("com.salesforce.util.exec").exec;
 var logoutInitiated = false;
 
 /**
- * Obtain authentication credentials, calling 'authenticate' only if necessary.
- * Most index.html authors can simply use this method to obtain auth credentials
- * after onDeviceReady.
+ * Obtain authentication credentials. Return the error "Not authenticated" if not authenticated.
  *   success - The success callback function to use.
  *   fail    - The failure/error callback function to use.
  * cordova returns a dictionary with:

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.oauth.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.oauth.js
@@ -38,9 +38,7 @@ var exec = require("com.salesforce.util.exec").exec;
 var logoutInitiated = false;
 
 /**
- * Obtain authentication credentials, calling 'authenticate' only if necessary.
- * Most index.html authors can simply use this method to obtain auth credentials
- * after onDeviceReady.
+ * Obtain authentication credentials. Return the error "Not authenticated" if not authenticated.
  *   success - The success callback function to use.
  *   fail    - The failure/error callback function to use.
  * cordova returns a dictionary with:

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -327,9 +327,7 @@ cordova.define("com.salesforce.plugin.oauth", function (require, exports, module
     var logoutInitiated = false;
 
     /**
-     * Obtain authentication credentials, calling 'authenticate' only if necessary.
-     * Most index.html authors can simply use this method to obtain auth credentials
-     * after onDeviceReady.
+     * Obtain authentication credentials. Return the error "Not authenticated" if not authenticated.
      *   success - The success callback function to use.
      *   fail    - The failure/error callback function to use.
      * cordova returns a dictionary with:

--- a/libs/force.js
+++ b/libs/force.js
@@ -349,17 +349,28 @@ var force = (function () {
                 errorHandler('Salesforce Mobile SDK OAuth plugin not available');
                 return;
             }
+
+            var authSuccess = function(creds) {
+                // Initialize ForceJS
+                init({accessToken: creds.accessToken, instanceURL: creds.instanceUrl, refreshToken: creds.refreshToken});
+                if (typeof successHandler === "function") successHandler();
+            };
+
+            var authFailure = function(error) {
+                console.log(error);
+                if (typeof errorHandler === "function") errorHandler(error);
+            };
+
             oauthPlugin.getAuthCredentials(
-                function (creds) {
-                    // Initialize ForceJS
-                    init({accessToken: creds.accessToken, instanceURL: creds.instanceUrl, refreshToken: creds.refreshToken});
-                    if (typeof successHandler === "function") successHandler();
-                },
-                function (error) {
-                    console.log(error);
-                    if (typeof errorHandler === "function") errorHandler(error);
+                authSuccess,
+                function() {
+                    oauthPlugin.authenticate(
+                        authSuccess,
+                        authFailure
+                    );
                 }
             );
+            
         }, false);
     }
 


### PR DESCRIPTION
…a login flow if not authenticated.

iOS implementation used to call authenticate() if not authenticated while Android implementation used to return the error "Not authenticated".
In 6.0, we are standardizing with the Android behavior.
Updating force.login() function to work with the new behavior (it was working on Android only if shouldAuthenticate was false).
Updated comment in oauth plugin also.