### PR TITLE
change from undefined to defined variable for push notification handler

### DIFF
--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -1230,7 +1230,7 @@ cordova.define("com.salesforce.util.push", function(require, exports, module) {
             push.on('error', function(e) {
                 console.log("push error");
                 console.error("push error " + JSON.stringify(e));
-                fail(err);
+                fail(e);
             });
         });
     };


### PR DESCRIPTION
Use the passed method parameter instead of undefined variable for push notification error handler