### PR TITLE
Binary download support

### DIFF
--- a/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
@@ -40,11 +40,10 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
 
     /* 
      * When requesting binary, the native code will send us {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
-     * We base 64 decode and create a blob
+     * We base-64 decode the body and create a blob from it using the specified contentType
      */
     if (returnResponseAsBlob) {
         responseHandler = function(response) {
-            // We expect response of the form 
             var byteCharacters = window.atob(response.encodedBody);
             var byteNumbers = new Array(byteCharacters.length);
 

--- a/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
@@ -62,7 +62,7 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
      */
     fileParams = fileParams || {};
     var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams, returnResponseAsBlob: returnResponseAsBlob};
-    exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
+    exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgSendRequest", [args]);
 };
 
 /**

--- a/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
@@ -46,9 +46,33 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
     exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
 };
 
+
+var requestBinary = function(endPoint, path, successCB, errorCB, payload, headerParams) {
+    var responseHandler = function(response) {
+        // We expect response of the form {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
+        var byteCharacters = window.atob(response.encodedBody);
+        var byteNumbers = new Array(byteCharacters.length);
+
+        for (var i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        var byteArray = new Uint8Array(byteNumbers);
+        successCB(new Blob([byteArray], {type: response.contentType}));
+    };
+
+    method = "GET";
+    payload = payload || {};
+    headerParams = headerParams || {};
+
+    var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams};
+    exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgRequestBinary", [args]);
+};
+
+
 /**
  * Part of the module that is public.
  */
 module.exports = {
-    sendRequest: sendRequest
+    sendRequest: sendRequest,
+    requestBinary: requestBinary
 };

--- a/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins/com.salesforce/com.salesforce.plugin.network.js
@@ -32,47 +32,42 @@ var exec = require("com.salesforce.util.exec").exec;
 /**
  * Sends a network request using the native network stack.
  */
-var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams) {
+var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnResponseAsBlob) {
     method = method || "GET";
     payload = payload || {};
     headerParams = headerParams || {};
+    var responseHandler = successCB;
+
+    /* 
+     * When requesting binary, the native code will send us {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
+     * We base 64 decode and create a blob
+     */
+    if (returnResponseAsBlob) {
+        responseHandler = function(response) {
+            // We expect response of the form 
+            var byteCharacters = window.atob(response.encodedBody);
+            var byteNumbers = new Array(byteCharacters.length);
+
+            for (var i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            var byteArray = new Uint8Array(byteNumbers);
+            successCB(new Blob([byteArray], {type: response.contentType}));
+        };
+    }
 
     /*
      * File params expected to be of the form:
      * {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}.
      */
     fileParams = fileParams || {};
-    var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams};
+    var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams, returnResponseAsBlob: returnResponseAsBlob};
     exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
 };
-
-
-var requestBinary = function(endPoint, path, successCB, errorCB, payload, headerParams) {
-    var responseHandler = function(response) {
-        // We expect response of the form {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
-        var byteCharacters = window.atob(response.encodedBody);
-        var byteNumbers = new Array(byteCharacters.length);
-
-        for (var i = 0; i < byteCharacters.length; i++) {
-            byteNumbers[i] = byteCharacters.charCodeAt(i);
-        }
-        var byteArray = new Uint8Array(byteNumbers);
-        successCB(new Blob([byteArray], {type: response.contentType}));
-    };
-
-    method = "GET";
-    payload = payload || {};
-    headerParams = headerParams || {};
-
-    var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams};
-    exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgRequestBinary", [args]);
-};
-
 
 /**
  * Part of the module that is public.
  */
 module.exports = {
-    sendRequest: sendRequest,
-    requestBinary: requestBinary
+    sendRequest: sendRequest
 };

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
@@ -47,10 +47,34 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
     exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
 };
 
+
+var requestBinary = function(endPoint, path, successCB, errorCB, payload, headerParams) {
+    var responseHandler = function(response) {
+        // We expect response of the form {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
+        var byteCharacters = window.atob(response.encodedBody);
+        var byteNumbers = new Array(byteCharacters.length);
+
+        for (var i = 0; i < byteCharacters.length; i++) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+        }
+        var byteArray = new Uint8Array(byteNumbers);
+        successCB(new Blob([byteArray], {type: response.contentType}));
+    };
+
+    method = "GET";
+    payload = payload || {};
+    headerParams = headerParams || {};
+
+    var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams};
+    exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgRequestBinary", [args]);
+};
+
+
 /**
  * Part of the module that is public.
  */
 module.exports = {
-    sendRequest: sendRequest
+    sendRequest: sendRequest,
+    requestBinary: requestBinary
 };
 });

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
@@ -41,11 +41,10 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
 
     /* 
      * When requesting binary, the native code will send us {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
-     * We base 64 decode and create a blob
+     * We base-64 decode the body and create a blob from it using the specified contentType
      */
     if (returnResponseAsBlob) {
         responseHandler = function(response) {
-            // We expect response of the form 
             var byteCharacters = window.atob(response.encodedBody);
             var byteNumbers = new Array(byteCharacters.length);
 

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.plugin.network.js
@@ -63,7 +63,7 @@ var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, 
      */
     fileParams = fileParams || {};
     var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams, returnResponseAsBlob: returnResponseAsBlob};
-    exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
+    exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgSendRequest", [args]);
 };
 
 /**

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -445,7 +445,7 @@ cordova.define("com.salesforce.plugin.network", function(require, exports, modul
          */
         fileParams = fileParams || {};
         var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams, returnResponseAsBlob: returnResponseAsBlob};
-        exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
+        exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgSendRequest", [args]);
     };
 
     /**

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -429,11 +429,35 @@ cordova.define("com.salesforce.plugin.network", function(require, exports, modul
         exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
     };
 
+
+    var requestBinary = function(endPoint, path, successCB, errorCB, payload, headerParams) {
+        var responseHandler = function(response) {
+            // We expect response of the form {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
+            var byteCharacters = window.atob(response.encodedBody);
+            var byteNumbers = new Array(byteCharacters.length);
+
+            for (var i = 0; i < byteCharacters.length; i++) {
+                byteNumbers[i] = byteCharacters.charCodeAt(i);
+            }
+            var byteArray = new Uint8Array(byteNumbers);
+            successCB(new Blob([byteArray], {type: response.contentType}));
+        };
+
+        method = "GET";
+        payload = payload || {};
+        headerParams = headerParams || {};
+
+        var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams};
+        exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgRequestBinary", [args]);
+    };
+
+
     /**
      * Part of the module that is public.
      */
     module.exports = {
-        sendRequest: sendRequest
+        sendRequest: sendRequest,
+        requestBinary: requestBinary
     };
 });
 

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -423,11 +423,10 @@ cordova.define("com.salesforce.plugin.network", function(require, exports, modul
 
         /* 
          * When requesting binary, the native code will send us {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
-         * We base 64 decode and create a blob
+         * We base-64 decode the body and create a blob from it using the specified contentType
          */
         if (returnResponseAsBlob) {
             responseHandler = function(response) {
-                // We expect response of the form 
                 var byteCharacters = window.atob(response.encodedBody);
                 var byteNumbers = new Array(byteCharacters.length);
 

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -415,49 +415,44 @@ cordova.define("com.salesforce.plugin.network", function(require, exports, modul
     /**
      * Sends a network request using the native network stack.
      */
-    var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams) {
+    var sendRequest = function(endPoint, path, successCB, errorCB, method, payload, headerParams, fileParams, returnResponseAsBlob) {
         method = method || "GET";
         payload = payload || {};
         headerParams = headerParams || {};
+        var responseHandler = successCB;
+
+        /* 
+         * When requesting binary, the native code will send us {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
+         * We base 64 decode and create a blob
+         */
+        if (returnResponseAsBlob) {
+            responseHandler = function(response) {
+                // We expect response of the form 
+                var byteCharacters = window.atob(response.encodedBody);
+                var byteNumbers = new Array(byteCharacters.length);
+
+                for (var i = 0; i < byteCharacters.length; i++) {
+                    byteNumbers[i] = byteCharacters.charCodeAt(i);
+                }
+                var byteArray = new Uint8Array(byteNumbers);
+                successCB(new Blob([byteArray], {type: response.contentType}));
+            };
+        }
 
         /*
          * File params expected to be of the form:
          * {<fileParamNameInPost>: {fileMimeType:<someMimeType>, fileUrl:<fileUrl>, fileName:<fileNameForPost>}}.
          */
         fileParams = fileParams || {};
-        var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams};
+        var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams, fileParams: fileParams, returnResponseAsBlob: returnResponseAsBlob};
         exec(SALESFORCE_MOBILE_SDK_VERSION, successCB, errorCB, SERVICE, "pgSendRequest", [args]);
     };
-
-
-    var requestBinary = function(endPoint, path, successCB, errorCB, payload, headerParams) {
-        var responseHandler = function(response) {
-            // We expect response of the form {encodedBody: "base-64-encoded-body", contentType: "mime-type"}
-            var byteCharacters = window.atob(response.encodedBody);
-            var byteNumbers = new Array(byteCharacters.length);
-
-            for (var i = 0; i < byteCharacters.length; i++) {
-                byteNumbers[i] = byteCharacters.charCodeAt(i);
-            }
-            var byteArray = new Uint8Array(byteNumbers);
-            successCB(new Blob([byteArray], {type: response.contentType}));
-        };
-
-        method = "GET";
-        payload = payload || {};
-        headerParams = headerParams || {};
-
-        var args = {endPoint: endPoint, path:path, method:method, queryParams:payload, headerParams:headerParams};
-        exec(SALESFORCE_MOBILE_SDK_VERSION, responseHandler, errorCB, SERVICE, "pgRequestBinary", [args]);
-    };
-
 
     /**
      * Part of the module that is public.
      */
     module.exports = {
-        sendRequest: sendRequest,
-        requestBinary: requestBinary
+        sendRequest: sendRequest
     };
 });
 

--- a/libs/force.js
+++ b/libs/force.js
@@ -488,7 +488,7 @@ var force = (function () {
                 if (xhr.status > 199 && xhr.status < 300) {
                     if (typeof successHandler === "function") {
                         if (returnBinary) {
-                            successHandler(new Blob([xhr.response], {type: this.getResponseHeader("content-type")}));
+                            successHandler(xhr.response);
                         } else {
                             successHandler(xhr.responseText ? JSON.parse(xhr.responseText) : undefined);
                         }
@@ -535,6 +535,9 @@ var force = (function () {
         }
         if (useProxy) {
             xhr.setRequestHeader("Target-URL", oauth.instance_url);
+        }
+        if (returnBinary) {
+            xhr.responseType = "blob";
         }
         xhr.send(obj.data ? JSON.stringify(obj.data) : undefined);
     }


### PR DESCRIPTION
New flag `returnResponseAsBlob` (default false) in network plugin `sendRequest` method and force.js `request()` method - when true expects a JavaScript Blob back.
* Updated the network plugin
The native side of the network plugin will send back the base64 encoded body and the content type and the javascript side of the network plugin takes care of decoding the body and building a JavaScript blob from it.
* Updated force.js also - it also works when running in a browser. There was a `getAttachment()` method in force.js already but it was broken.

Example
```javascript
    force.getAttachment("--valid-attachment-id--",
            function(blob) {
              document.getElementById("--id-of-some-img-tag").src = URL.createObjectURL(blob);
            },
            function(error) {
                alert("error->[" + error + "]");
            }
        );

```

Note: Will send a PR to https://github.com/ccoenraets/forcejs once 6.0 ships. 