### PR TITLE
Upsert with null external id

### DIFF
--- a/libs/force.js
+++ b/libs/force.js
@@ -840,9 +840,9 @@ var force = (function () {
 
         return request(
             {
-                method: 'PATCH',
+                method: externalId ? 'PATCH':'POST',
                 contentType: 'application/json',
-                path: '/services/data/' + apiVersion + '/sobjects/' + objectName + '/' + externalIdField + '/' + externalId,
+                path: '/services/data/' + apiVersion + '/sobjects/' + objectName + '/' + externalIdField + '/' + (externalId ? externalId :''),
                 data: data
             },
             successHandler,


### PR DESCRIPTION
Since v37, upsert with external id null is allowed - it does a create (but post must be used).
We made the change on the native side last year.