### PR TITLE
Make perf marker tag unique to fix the case when there two overlapping operations of the same type

### DIFF
--- a/gen/plugins/com.salesforce/com.salesforce.util.exec.js
+++ b/gen/plugins/com.salesforce/com.salesforce.util.exec.js
@@ -27,7 +27,8 @@
 // Version this js was shipped with
 var SALESFORCE_MOBILE_SDK_VERSION = "7.3.0";
 var exec = function(pluginVersion, successCB, errorCB, service, action, args) {
-    var tag = "TIMING " + service + ":" + action;
+    var uniqueNumber = new Date().valueOf() + Math.random();
+    var tag = "TIMING " + service + ":" + action + ":" + uniqueNumber;
     console.time(tag);
     args.unshift("pluginSDKVersion:" + pluginVersion);
     var cordovaExec = require('cordova/exec');

--- a/gen/plugins_with_define/com.salesforce/com.salesforce.util.exec.js
+++ b/gen/plugins_with_define/com.salesforce/com.salesforce.util.exec.js
@@ -28,7 +28,8 @@ cordova.define("com.salesforce.util.exec", function(require, exports, module) {
 // Version this js was shipped with
 var SALESFORCE_MOBILE_SDK_VERSION = "7.3.0";
 var exec = function(pluginVersion, successCB, errorCB, service, action, args) {
-    var tag = "TIMING " + service + ":" + action;
+    var uniqueNumber = new Date().valueOf() + Math.random();
+    var tag = "TIMING " + service + ":" + action + ":" + uniqueNumber;
     console.time(tag);
     args.unshift("pluginSDKVersion:" + pluginVersion);
     var cordovaExec = require('cordova/exec');

--- a/libs/cordova.force.js
+++ b/libs/cordova.force.js
@@ -182,7 +182,8 @@ cordova.define("com.salesforce.util.bootstrap", function(require, exports, modul
  */
 cordova.define("com.salesforce.util.exec", function(require, exports, module) {
     var exec = function(pluginVersion, successCB, errorCB, service, action, args) {
-        var tag = "TIMING " + service + ":" + action;
+        var uniqueNumber = new Date().valueOf() + Math.random();
+        var tag = "TIMING " + service + ":" + action + ":" + uniqueNumber;
         console.time(tag);
         args.unshift("pluginSDKVersion:" + pluginVersion);
         var cordovaExec = require('cordova/exec');


### PR DESCRIPTION
Gus Bug: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000077azDIAQ/view

In cordova.js, there is a function called exec as part of com.salesforce.util.exec JS module. That function is used for async smartstore operations and is using console.time() and console.timeEnd() to log the time of a given operation.



The key given as identifier is var tag = "TIMING " + service + ":" + action;



The issue is that the key is not unique and when concurrent operations are executed, the console.time() calls will conflict with each other. For example, if we execute a smartstore pgRunSmartQuery operation, the key will be TIMING com.salesforce.smartstore:pgRunSmartQuery. I observed cases where a short operation (say A) was followed by a longer operation (say B) in parallel. In that case, B started and ended before A completed. The timer would start for A, then it would be ignored for B since the key was already used. When B completed, the timer would stop since it’s using the same key. When A would complete, the timer would be ignored by B already triggered the stop. In another word we would measure the time between A start and B completes rather than the time for A and time for B. You can observe this by looking at the logs and often seeing warnings: “Timer X already exists” or “Timer X does not exist”



A simple fix would be to modify the tag to include a unique ID.