### PR TITLE
parseUrl can now handle full url or relative ones

### DIFF
--- a/libs/force.js
+++ b/libs/force.js
@@ -141,16 +141,22 @@ var force = (function () {
     }
 
     function parseUrl(url) {
-        var match = url.match(/^(https?\:)\/\/(([^:\/?#]*)(?:\:([0-9]+))?)([^?#]*)(\?[^#]*|)(#.*|)$/);
-        return match && {
-            protocol: match[1],
-            host: match[2],
-            hostname: match[3],
-            port: match[4],
-            path: match[5],
-            params: parseQueryString(match[6]),
-            hash: match[7]
-        };
+        try {
+            var relativePath = url.indexOf("/") == 0;
+            var url = new URL(relativePath ? "https://x" + url : url);
+            return url && {
+                protocol: relativePath ? "" : url.protocol,
+                host: relativePath ? "" : url.host,
+                hostname: relativePath ? "" : url.hostname,
+                port: url.port,
+                path: url.pathname,
+                params: parseQueryString(url.search),
+                hash: url.hash
+            };
+        }
+        catch (error) {
+            return null;
+        }
     }
 
     function refreshTokenWithPlugin(success, error) {


### PR DESCRIPTION
parseUrl("https://asdasd:123/abc/de?a=b&c=d")
=> {hash: "", host: "asdasd:123", hostname: "asdasd", params: {a: "b", c: "d"}, path: "/abc/de", port: "123", protocol: "https:"}

parseUrl("/abc/de?a=b&c=d")
=> {hash: "", host: "", hostname: "", params: {a: "b", c: "d"}, path: "/abc/de", port: "", protocol: ""}